### PR TITLE
SASS Cleanup

### DIFF
--- a/communitheme/gnome-shell-sass/_colors.scss
+++ b/communitheme/gnome-shell-sass/_colors.scss
@@ -1,36 +1,34 @@
 // When color definition differs for dark and light variant,
 // it gets @if ed depending on $variant
 @import "ubuntu-colors";
-// $base_color: if($variant =='light', #ffffff, #292929);
-// $bg_color: if($variant =='light', #ededed, #393f3f);
-// $fg_color: if($variant =='light', #2e3436, #eeeeec);
-$base_color: if($variant =='light', #ffffff, $ubuntu_base_color);
-$bg_color: if($variant =='light', #ededed, $ubuntu_bg_color);
-$fg_color: if($variant =='light', #2e3436, $ubuntu_fg_color);
-
+$base_color: if($variant == 'light', #FAFAFA, $jet);
+$bg_color: if($variant == 'light', #fdfdfd, #252525);
+$fg_color: if($variant == 'light', $slate, $porcelain);
+$text_color: transparentize($fg_color, .1);
+//
+$panel_bg_color: $jet;
+$panel_fg_color: $porcelain;
+$menu_color: #252525;
+//
 $selected_fg_color: #ffffff;
-$selected_bg_color: $orange; // if($variant == 'light', #4a90d9, darken(#4a90d9,20%));
-$selected_borders_color: if($variant=='light', darken($selected_bg_color, 30%),
-                                               darken($selected_bg_color, 20%));
+$selected_bg_color: $orange;
+$selected_borders_color: if($variant=='light', darken($selected_bg_color, 5%),
+                                               darken($selected_bg_color, 15%));
 $borders_color: if($variant =='light', darken($bg_color,30%), darken($bg_color,12%));
 $borders_edge: if($variant =='light', white, transparentize($fg_color, 0.9));
-$link_color: $blue; // if($variant == 'light', darken($selected_bg_color,10%),
-//                                     lighten($selected_bg_color,20%));
+$link_color: $blue;
+//
 $link_visited_color: if($variant == 'light', darken($link_color,20%),
                                      lighten($link_color,10%));
-$top_hilight: $borders_edge;
 $dark_fill: #C7C7C7;
-
+//
 $warning_color: $yellow;
 $error_color: $red;
 $success_color: $green;
 $destructive_color: darken($red, 10%);
 $neutral_color: $blue;
-
-// $osd_fg_color: #eeeeec;
-// $osd_bg_color: #2e3436;
-// $osd_borders_color: transparentize(black, 0.3);
-// $osd_outer_borders_color: transparentize(white, 0.9);
+$indication_bg_color: #19B6EE;
+//
 $osd_fg_color: $fg_color;
 $osd_bg_color: $jet;
 $button_bg_color: lighten($osd_bg_color, 15%);;
@@ -39,21 +37,7 @@ $osd_borders_color: lighten($borders_color, 20%);
 $base_hover_color: transparentize($fg_color, 0.85);
 $base_active_color: transparentize($fg_color, 0.80);
 $active_fg_color: transparentize($selected_fg_color, .5);
-//
-$dialog_fg_color: $slate;
-$dialog_bg_color: $porcelain;
-$dialog_borders_color: darken(#F7F7F7, 25%);
-// $tooltip_borders_color: $osd_outer_borders_color; // is this being used?
-
 //insensitive state derived colors
 $insensitive_fg_color: mix($fg_color, $bg_color, 50%);
 $insensitive_bg_color: mix($bg_color, $base_color, 60%);
 $insensitive_borders_color: $borders_color;
-
-//colors for the backdrop state, derived from the main colors.
-$backdrop_base_color: if($variant =='light', darken($base_color,1%), lighten($base_color,1%));
-$backdrop_bg_color: $bg_color;
-$backdrop_fg_color: mix($fg_color, $backdrop_bg_color, 80%);
-$backdrop_insensitive_color: if($variant =='light', darken($backdrop_bg_color,15%), lighten($backdrop_bg_color,15%));
-$backdrop_borders_color: mix($borders_color, $bg_color, 90%);
-$backdrop_dark_fill: mix($backdrop_borders_color,$backdrop_bg_color, 35%);

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -32,7 +32,7 @@ $popover-alpha-value: 0.025;
 /* GLOBALS */
 $font-size: 11;
 $font-family: Ubuntu, Cantarell, Sans-Serif;
-$_bubble_bg_color: transparentize($osd_bg_color, $popover-alpha-value);
+$_dialog_bg_color: transparentize($osd_bg_color, $popover-alpha-value);
 
 stage {
   font-family: $font-family;
@@ -185,7 +185,7 @@ StScrollBar {
 .modal-dialog {
   border-radius: 6px;
   color: $osd_fg_color;
-  background-color: $_bubble_bg_color;
+  background-color: $_dialog_bg_color;
   border: 1px solid $osd_borders_color;
   .modal-dialog-content-box {
     padding: 24px;
@@ -724,7 +724,7 @@ StScrollBar {
 
 %osd-panel {
   color: $osd_fg_color;
-  background-color: $_bubble_bg_color;
+  background-color: $_dialog_bg_color;
   border: 1px solid $osd_borders_color;
   border-radius: 12px;
   padding: 12px;
@@ -1333,7 +1333,7 @@ StScrollBar {
     // TODO: style the ubuntu dock, not this
     font-size: 9pt;
     color: $osd_fg_color;
-    background-color: $_bubble_bg_color;
+    background-color: $_dialog_bg_color;
     padding: 4px 0;
     border: 1px solid $osd_borders_color;
     border-left: 0px;
@@ -1534,7 +1534,7 @@ StScrollBar {
 
 %overview-panel {
   color: $osd_fg_color;
-  background-color: $_bubble_bg_color;
+  background-color: $_dialog_bg_color;
   border: 1px solid $osd_borders_color;
 }
 
@@ -1573,11 +1573,11 @@ StScrollBar {
       // padding: 4px 4px 5px;
       min-height: 22px; // make just a little taller
       padding: 4px 32px;
-      background-color: darken($_bubble_bg_color,5%);
+      background-color: darken($_dialog_bg_color,5%);
       &:first-child { border-radius: 0 0 0 6px; }
       &:last-child { border-radius: 0 0 6px 0; }
-      &:hover, &:focus { background-color: darken($_bubble_bg_color,2%); }
-      &:active { background-color: darken($_bubble_bg_color, 5%); }
+      &:hover, &:focus { background-color: darken($_dialog_bg_color,2%); }
+      &:active { background-color: darken($_dialog_bg_color, 5%); }
     }
   }
   .summary-source-counter {

--- a/communitheme/gnome-shell-sass/_ubuntu-colors.scss
+++ b/communitheme/gnome-shell-sass/_ubuntu-colors.scss
@@ -17,14 +17,4 @@ $yellow: #F89B0F;
 $green: #46B258;
 $blue: #30B3EA;
 $purple: #74296F;
-
-// Widget Colors
-$panel_bg_color: $jet;
-$panel_fg_color: $porcelain;
-$menu_color: #252525;
-$indication_bg_color: #19B6EE;
 //
-$ubuntu_base_color: if($variant == 'light', #FAFAFA, $jet);
-$ubuntu_bg_color: if($variant == 'light', #fdfdfd, #252525);
-$ubuntu_fg_color: if($variant == 'light', $slate, $porcelain);
-$ubuntu_text_color: transparentize($ubuntu_fg_color, .1);


### PR DESCRIPTION
- Start using colors we've settled in _colors as opposed to _ubuntu-colors
- Get rid of things we aren't using
- Rename _bubble_bg_color to a more indicative _dialog_bg_color