### PR TITLE
Update app view buttons and calendar selected day

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -991,8 +991,8 @@ StScrollBar {
       border-radius: 6px; // 1.4em;
       &:hover,&:focus { background-color: lighten($bg_color,5%); }
       &:active,&:selected {
-        color: lighten($selected_fg_color, 5%);
-        background-color: $indication_bg_color;
+        background-color: $base_active_color;
+        color: $indication_bg_color;
         border-color: transparent; //avoid jumparound due to today
       }
       &.calendar-day-heading {  //day of week heading
@@ -1392,13 +1392,24 @@ StScrollBar {
   }
   .app-view-control { //favorties | all toggle button
     padding: 4px 32px;
-    &:checked { @include button(active); }
+    margin: 0 4px;
+    &, &:hover, &:checked { @include button(undecorated); } // reset
+
+    color: $insensitive_fg_color;
+    &:hover { box-shadow: inset 0 -2px $insensitive_fg_color; color: $fg_color }
+
+    &:checked {
+      color: $fg_color;
+      box-shadow: inset 0 -2px $selected_bg_color;
+    }
+
     &:first-child {
       border-right-width: 0;
-      border-radius: 3px 0 0 3px;
+      border-radius: 0;
     }
+
     &:last-child {
-     border-radius: 0 3px 3px 0;
+     border-radius: 0;
     }
   }
 


### PR DESCRIPTION
- Update app view buttons to emulate GTK3 stackswitcher style (underline effect)
- Selected days in the calendar popover use blue as its text color as opposed to its background color
  Closes #4