### PR TITLE
Some packaging/instructions cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,12 @@ Communitheme is the new Ubuntu theme build by the Community.
 *Note: these instructions install the entire Communitheme session; this includes the Gnome Shell, GTK and icon theme.*
 
 ```bash
-# First, make sure the old versions are removed
-sudo apt remove suru-icon-theme gtk-communitheme gnome-shell-communitheme ubuntu-communitheme-session
-
 # Add the PPA to your repository list
 sudo add-apt-repository ppa:communitheme/ppa
 # Download a list of all the software that's available from the repositories
 sudo apt update
 # Download and install the actual software
-sudo apt install suru-icon-theme gtk-communitheme gnome-shell-communitheme ubuntu-communitheme-session
+sudo apt install ubuntu-communitheme-session
 ```
 
 And it's installed! Restart your computer, the login screen will use Communitheme by default. Select the "Ubuntu Communitheme" session from the login screen (click the gear) and login. This will start the GNOME-Shell, GTK2, GTK3 and icon themes.

--- a/debian/control
+++ b/debian/control
@@ -25,6 +25,8 @@ Architecture: all
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          gnome-shell-communitheme (= ${source:Version}),
+         gtk-communitheme,
+         suru-icon-theme,
 Description: session starting Ubuntu Community Theme
  This is the session enabling starting easily the theme
  that is shaped by the community on the Ubuntu hub.


### PR DESCRIPTION
Ensure we only need to install the session package to have the theme installed.
Update the instructions for it.

It can be merged from it, the builders did catch up.
Followup from https://github.com/Ubuntu/gnome-shell-communitheme/pull/9
Note the build will fail due to missing .travis.yml file (next PR is adding it)