### PR TITLE
Entry field updates/fixes

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -88,6 +88,7 @@ stage {
 StEntry {
   border-radius: $small_radius;
   border-width: 1px;
+  min-height: 22px;
   padding: 4px;
   @include entry(normal);
   //&:hover { @include entry(hover);}
@@ -199,6 +200,8 @@ StScrollBar {
   .run-dialog-entry {
     width: 20em;
     margin-bottom: 6px;
+
+    &:focus { border-color: $selected_bg_color; }
   }
   .run-dialog-error-box {
     padding-top: 16px;
@@ -1287,14 +1290,15 @@ StScrollBar {
   //search entry
   .search-entry {
     width: 320px;
-    padding: 7px 9px;
     border-radius: $small_radius;
     border-color: $osd_borders_color;
     color: $osd_fg_color;
     background-color: $osd_bg_color;
+
+    &, &:focus { padding: 7px 9px; }
+
     &:focus {
-      padding: 6px 8px;
-      border-width: 2px;
+      border-width: 1px;
       border-color: $selected_bg_color;
     }
 

--- a/communitheme/gnome-shell-sass/_drawing.scss
+++ b/communitheme/gnome-shell-sass/_drawing.scss
@@ -46,7 +46,7 @@
   }
   @if $t==focus {
     color: $tc;
-    border-color: if($fc==$selected_bg_color, $selected_borders_color, darken($fc,35%));
+    border-color: $fc;
     box-shadow: none;
   }
   @if $t==hover { } // TODO: should we bother?

--- a/communitheme/gnome-shell-sass/_ubuntu-colors.scss
+++ b/communitheme/gnome-shell-sass/_ubuntu-colors.scss
@@ -17,4 +17,3 @@ $yellow: #F89B0F;
 $green: #3EB34F;
 $blue: #19B6EE;
 $purple: #762572;
-//


### PR DESCRIPTION
- Entry field on the login screen would increase in size when text is entered (using min-height gets around that)
- Focused entry fields use a 1px border instead of a double border (to match with the GTK theme)

Closes #27