### PR TITLE
Use separator instead of box shadow for dock + update selected bg color

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -479,7 +479,8 @@ StScrollBar {
   .audio-selection-device {
     border: 1px solid $osd_borders_color; // $osd_borders_color;
     border-radius: 12px;
-    &:active,&:hover,&:focus { background-color: $selected_bg_color; }
+    &:hover,&:focus { background-color: $base_hover_color; }
+    &:active { background-color: $base_active_color; }
   }
 
   .audio-selection-device-box {
@@ -1232,7 +1233,7 @@ StScrollBar {
 
   .nm-dialog-airplane-text { color: $fg_color; }
   .nm-dialog-header-icon { icon-size: 32px; }
-  .nm-dialog-scroll-view { border: 1px solid $borders_color; } // 2px solid $borders_color; }
+  .nm-dialog-scroll-view { border: 1px solid $osd_borders_color; } // 2px solid $borders_color; }
   .nm-dialog-header { font-weight: bold; }
 
   .nm-dialog-item {
@@ -1243,7 +1244,7 @@ StScrollBar {
   }
 
   .nm-dialog-item:selected {
-    background-color: $selected_bg_color;
+    background-color: $base_hover_color;
     color: $selected_fg_color;
   }
 

--- a/communitheme/gnome-shell-sass/_dock.scss
+++ b/communitheme/gnome-shell-sass/_dock.scss
@@ -144,7 +144,7 @@
   // without border: none, there is a 1px gap between windows and the dock
   &.shrink #dash,
   &.dashtodock #dash {
-    box-shadow: inset 0 4px 3px rgba(0, 0, 0, 0.5) !important;
+    box-shadow: inset 0 1px $inkstone !important;
     border: none !important;
   }
 


### PR DESCRIPTION
- WiFi network selection used $selected_bg_color instead of $base_hover_color
- Try using a separator instead of a box shadow for the dock to match gtk3 windows