### PR TITLE
Underline panel-icon when active

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -832,8 +832,8 @@ StScrollBar {
     &:active, &:overview, &:focus, &:checked {
       // Trick due to St limitations. It needs a background to draw
       // a box-shadow
-      background-color: $base_active_color; // rgba(0, 0, 0, 0.01);
-      box-shadow: inset 0 2px 2px -2px transparentize(black, .5); // inset 0 -2px 0px lighten($selected_bg_color,5%);
+      background-color: rgba(0, 0, 0, 0.01);
+      box-shadow: inset 0px -3px $selected_bg_color;
       color: lighten($_fg,10%);
 
       & > .system-status-icon { icon-shadow: none; /*black 0 2px 2px;*/ }


### PR DESCRIPTION
In place of an highlight, panel-icon now gets an orange underline when
active.

NOTE: this change works best with transparent top panel due to the
orange base color of usual Ubuntu desktop background

closes #42