### PR TITLE
Use Suru style user icon in GDM

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1778,13 +1778,14 @@ StScrollBar {
 /* Auth Dialogs & Screen Shield */
 
 .framed-user-icon {
+  background-image: url("user-icon.svg");
   background-size: contain;
-  border: 2px solid $osd_fg_color;
-  color: $osd_fg_color;
+  border: none;
+  color: transparent;
   border-radius: $small_radius;
   &:hover {
-    border-color: lighten($osd_fg_color,30%);
-    color: lighten($osd_fg_color,30%);
+    border-color: transparent;
+    color: transparent;
   }
 }
 

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1778,7 +1778,7 @@ StScrollBar {
 /* Auth Dialogs & Screen Shield */
 
 .framed-user-icon {
-  background-image: url("user-icon.svg");
+  background-image: url("resource:///org/gnome/shell/theme/user-icon.svg");
   background-size: contain;
   border: none;
   color: transparent;

--- a/communitheme/meson.build
+++ b/communitheme/meson.build
@@ -53,6 +53,7 @@ data_sources = [
   'toggle-on-intl.svg',
   'toggle-on-us.svg',
   'ubuntu-logo-icon.svg',
+  'user-icon.svg',
   'ws-switch-arrow-down.svg',
   'ws-switch-arrow-up.svg',
 ]

--- a/communitheme/user-icon.svg
+++ b/communitheme/user-icon.svg
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="96"
+   height="96"
+   id="svg4874"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   viewBox="0 0 96 96.000001"
+   sodipodi:docname="account02.svg">
+  <defs
+     id="defs4876" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.0249989"
+     inkscape:cx="-13.430614"
+     inkscape:cy="62.55515"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4322"
+     showgrid="true"
+     showborder="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5451"
+       empspacing="8" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="8,-8.0000001"
+       id="guide4063"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="4,-8.0000001"
+       id="guide4065"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-8,88.000001"
+       id="guide4067"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-8,92.000001"
+       id="guide4069"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="104,4"
+       id="guide4071"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-5,8.0000001"
+       id="guide4073"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="92,-8.0000001"
+       id="guide4075"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="88,-8.0000001"
+       id="guide4077"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-8,84.000001"
+       id="guide4074"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="12,-8.0000001"
+       id="guide4076"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-5,12"
+       id="guide4078"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="84,-9.0000001"
+       id="guide4080"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="48,-8.0000001"
+       orientation="1,0"
+       id="guide4170"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="-8,48"
+       orientation="0,1"
+       id="guide4172"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata4879">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(67.857146,-78.50504)">
+    <g
+       transform="matrix(0,-1,-1,0,373.50506,516.50504)"
+       id="g4845"
+       style="display:inline">
+      <g
+         inkscape:export-ydpi="90"
+         inkscape:export-xdpi="90"
+         inkscape:export-filename="next01.png"
+         transform="matrix(-0.9996045,0,0,1,575.94296,-611.00001)"
+         id="g4778"
+         inkscape:label="Layer 1">
+        <g
+           transform="matrix(-1,0,0,1,575.99999,611)"
+           id="g4780"
+           style="display:inline">
+          <rect
+             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:4;marker:none;enable-background:accumulate"
+             id="rect4782"
+             width="96.037987"
+             height="96"
+             x="-438.00244"
+             y="345.36221"
+             transform="scale(-1,1)" />
+          <ellipse
+             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#808080;stroke-width:4.00079107;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+             id="path4116"
+             cx="-393.36163"
+             cy="-389.98404"
+             rx="39.999001"
+             ry="40.014828"
+             transform="matrix(0,-1,-1,0,0,0)" />
+          <g
+             id="g4322"
+             transform="matrix(0.71170999,0,0,0.71172026,128.56001,-20.188226)"
+             style="stroke-width:1.4050566">
+            <path
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:none;fill-opacity:1;stroke:#808080;stroke-width:5.62133741;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 388.44081,561.49957 q -4.792,0 -8.65654,1.44165 -3.86457,1.4416 -6.64701,4.0847 -2.7825,2.5629 -4.32831,6.16706 -1.46853,3.60409 -1.46853,7.84901 0,4.24482 1.46853,7.84893 1.54581,3.60415 4.32831,6.24719 2.78244,2.56292 6.64701,4.00455 3.86454,1.44167 8.65654,1.44167 4.71473,0 8.57932,-1.44167 3.94183,-1.44163 6.72426,-4.00455 2.78245,-2.64304 4.25099,-6.24719 1.54587,-3.60411 1.54587,-7.84893 0,-4.24492 -1.54587,-7.84901 -1.46854,-3.60416 -4.25099,-6.16706 -2.78243,-2.6431 -6.72426,-4.0847 -3.86459,-1.44165 -8.57932,-1.44165 z"
+               id="path4202-1"
+               inkscape:connector-curvature="0"
+               inkscape:transform-center-y="22.882134"
+               inkscape:transform-center-x="2.0946693e-05" />
+            <path
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:none;fill-opacity:1;stroke:#808080;stroke-width:5.62133789;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 326.6999,542.92516 c 20.00792,0.0144 26.62495,6.01394 26.62496,38.01417 0,32.00023 -6.61704,38.00023 -26.62496,38.04585"
+               id="path4228-7"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="czc" />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/communitheme/user-icon.svg
+++ b/communitheme/user-icon.svg
@@ -167,7 +167,7 @@
              y="345.36221"
              transform="scale(-1,1)" />
           <ellipse
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#808080;stroke-width:4.00079107;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#F7F7F7;stroke-width:4.00079107;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
              id="path4116"
              cx="-393.36163"
              cy="-389.98404"
@@ -179,14 +179,14 @@
              transform="matrix(0.71170999,0,0,0.71172026,128.56001,-20.188226)"
              style="stroke-width:1.4050566">
             <path
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:none;fill-opacity:1;stroke:#808080;stroke-width:5.62133741;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:none;fill-opacity:1;stroke:#F7F7F7;stroke-width:5.62133741;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
                d="m 388.44081,561.49957 q -4.792,0 -8.65654,1.44165 -3.86457,1.4416 -6.64701,4.0847 -2.7825,2.5629 -4.32831,6.16706 -1.46853,3.60409 -1.46853,7.84901 0,4.24482 1.46853,7.84893 1.54581,3.60415 4.32831,6.24719 2.78244,2.56292 6.64701,4.00455 3.86454,1.44167 8.65654,1.44167 4.71473,0 8.57932,-1.44167 3.94183,-1.44163 6.72426,-4.00455 2.78245,-2.64304 4.25099,-6.24719 1.54587,-3.60411 1.54587,-7.84893 0,-4.24492 -1.54587,-7.84901 -1.46854,-3.60416 -4.25099,-6.16706 -2.78243,-2.6431 -6.72426,-4.0847 -3.86459,-1.44165 -8.57932,-1.44165 z"
                id="path4202-1"
                inkscape:connector-curvature="0"
                inkscape:transform-center-y="22.882134"
                inkscape:transform-center-x="2.0946693e-05" />
             <path
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:none;fill-opacity:1;stroke:#808080;stroke-width:5.62133789;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:none;fill-opacity:1;stroke:#F7F7F7;stroke-width:5.62133789;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
                d="m 326.6999,542.92516 c 20.00792,0.0144 26.62495,6.01394 26.62496,38.01417 0,32.00023 -6.61704,38.00023 -26.62496,38.04585"
                id="path4228-7"
                inkscape:connector-curvature="0"


### PR DESCRIPTION
Here is the screenshot:

![image](https://user-images.githubusercontent.com/9556384/36252855-551e6cf4-1289-11e8-91dd-bdb147d02019.png)

There seems to be no effect with the user selection image:

![image](https://user-images.githubusercontent.com/9556384/36253230-4a801616-128a-11e8-89fb-d0976fe9f5e6.png)

Closes Ubuntu/gtk-communitheme#129