### PR TITLE
Adjusting panel and dock transparency and shadow

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -5,8 +5,8 @@ $cakeisalie: "This stylesheet is generated, DO NOT EDIT";
 /* #{$cakeisalie} */
 $panel-corner-radius: 0; // 6px;
 //
-$panel-alpha-value: 0.75;
-$dash-alpha-value: 0.6;
+$panel-alpha-value: 0.6;
+$dash-alpha-value: 0.5;
 $dash-opaque-alpha-value: 0.05;
 $popover-alpha-value: 0.025;
 //
@@ -765,7 +765,7 @@ StScrollBar {
 #panel {
   $_fg: $panel_fg_color;
   background-color: transparentize($panel_bg_color, $panel-alpha-value);
-  box-shadow: 0 3px 3px 4px rgba(0, 0, 0, 0.9);
+  box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.9);
   /* transition from solid to transparent */
   transition-duration: 500ms;
   font-weight: 450;
@@ -804,7 +804,6 @@ StScrollBar {
     font-weight: 450;
     color: $_fg;
     text-shadow: none;
-    text-shadow: 0px 1px 2px rgba(0, 0, 0, 0.7);
     transition-duration: 100ms;
 
     .app-menu-icon {
@@ -816,9 +815,9 @@ StScrollBar {
 
     .system-status-icon,
     .app-menu-icon > StIcon,
-    .popup-menu-arrow {
-      icon-shadow: 0px 1px 2px rgba(0, 0, 0, 0.7);
-    }
+    //.popup-menu-arrow {
+    //  icon-shadow: 0px 1px 2px rgba(0, 0, 0, 0.7);
+    //}
 
     &:hover {
       color: $hover_fg_color;


### PR DESCRIPTION
- Reduced transparency to 0.6 for panel and 0.5 for dock
- Shadow reduced as well to box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.9)
- Removed text and icon shadow

closes #53