### PR TITLE
Scale Ubuntu logo properly

### DIFF
--- a/communitheme/gnome-shell-sass/_dock.scss
+++ b/communitheme/gnome-shell-sass/_dock.scss
@@ -197,11 +197,11 @@
     &,
     &:focus, &:hover,
     &:active, &:checked {
-      .overview-icon {
+      .show-apps-icon {
         background-image: url("ubuntu-logo-icon.svg") !important;
         background-position: center;
         background-repeat: no-repeat;
-        background-size: 48px !important;
+        background-size: contain !important;
       }
     }
   }

--- a/communitheme/ubuntu-logo-icon.svg
+++ b/communitheme/ubuntu-logo-icon.svg
@@ -19,8 +19,8 @@
    inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
    version="1.1"
    id="svg3336"
-   height="96"
-   width="96">
+   height="48"
+   width="48">
   <sodipodi:namedview
      inkscape:snap-global="false"
      fit-margin-bottom="18"

--- a/communitheme/ubuntu-logo-icon.svg
+++ b/communitheme/ubuntu-logo-icon.svg
@@ -19,8 +19,8 @@
    inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
    version="1.1"
    id="svg3336"
-   height="48"
-   width="48">
+   height="96"
+   width="96">
   <sodipodi:namedview
      inkscape:snap-global="false"
      fit-margin-bottom="18"


### PR DESCRIPTION
While doubling the source ubuntu-logo-icon.svg to avoid blurring
when the icon size is more than 48px.

Fixes #69