### PR TITLE
Rebase communitheme on GNOME Shell 3.27.92 and switch to bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - docker
 
 env:
-  - TRAVIS_DEBIAN_DISTRIBUTION=artful TRAVIS_DEBIAN_BACKPORTS="artful-security artful-updates" TRAVIS_DEBIAN_INCREMENT_VERSION_NUMBER=true
+  - TRAVIS_DEBIAN_DISTRIBUTION=bionic TRAVIS_DEBIAN_BACKPORTS="bionic-security bionic-updates" TRAVIS_DEBIAN_INCREMENT_VERSION_NUMBER=true
 
 script:
   - wget -O- https://raw.githubusercontent.com/lamby/travis.debian.net/gh-pages/script.sh | sh -

--- a/communitheme/README
+++ b/communitheme/README
@@ -1,12 +1,9 @@
 Summary
 -------
 
-* Do not edit the CSS directly, edit the source SCSS files and process them with SASS (running
-  `make` should do that when you have the required software installed, as described below;
-  run `./parse-sass.sh` manually if it doesn't)
-* Most SASS preprocessors should produce similar results, however the build system
-  integration and 'parse-sass.sh' script use sassc. You should be able to install
-  it with `pkcon install sassc` or your distribution's package manager.
+* Do not edit the CSS directly, edit the source SCSS files and the CSS files will be generated
+  automatically when building with meson + ninja and left inside the build directory to be
+  incorporated into the gresource XML (you'll need to have sassc installed).
 
 How to tweak the theme
 ----------------------
@@ -31,4 +28,4 @@ _common.scss        - actual definitions of style for each widget. This is where
                       your changes.
                       
 You can read about SASS at http://sass-lang.com/documentation/. Once you make your changes to the
-_common.scss file, you can either run make or the ./parse-sass.sh script.
+_common.scss file, you can run ninja to generate the final CSS files.

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -749,7 +749,7 @@ StScrollBar {
 }
 
   .tile-preview-left.on-primary {
-    border-radius: $panel-corner-radius $panel-corner-radius 0 0;
+    border-radius: $panel-corner-radius 0 0 0;
   }
 
   .tile-preview-right.on-primary {
@@ -876,7 +876,7 @@ StScrollBar {
       color: $_fg;
       text-shadow: none;
 
-      &:hover {
+      &:hover, &:active, &:overview, &:focus, &:checked {
         color: $hover_fg_color;
       }
     }
@@ -951,6 +951,7 @@ StScrollBar {
 
     .datemenu-today-button .date-label {
       font-size: 1.5em;
+      font-weight: 300;
     }
 
     .world-clocks-header,
@@ -1162,6 +1163,12 @@ StScrollBar {
   .aggregate-menu {
     min-width: 21em;
     .popup-menu-icon { padding: 0 4px; }
+    .popup-sub-menu .popup-menu-item :first-child {
+      &:ltr { /* 12px spacing + 2*4px padding */
+              padding-left: 20px; margin-left: 1.09em; }
+      &:rtl { /* 12px spacing + 2*4px padding */
+              padding-right: 20px; margin-right: 1.09em; }
+    }
   }
 
   .system-menu-action {
@@ -1546,6 +1553,12 @@ StScrollBar {
     border-radius: 9px 0 0 9px;
     //border-width: 1px 0 1px 1px; //fixme: can't have non unoform borders :(
     &:rtl { border-radius: 0 9px 9px 0;}
+
+    .placeholder {
+      background-image: url("resource:///org/gnome/shell/theme/dash-placeholder.svg");
+      background-size: contain;
+      height: 24px;
+    }
   }
   .workspace-thumbnail-indicator {
     border: 4px solid $selected_bg_color;
@@ -1699,27 +1712,31 @@ StScrollBar {
 
 //Keyboard
 /* On-screen Keyboard */
+.word-suggestions {
+    font-size: 14pt;
+    spacing: 12px;
+    min-height: 20pt;
+}
 
 #keyboard {
     background-color: transparentize($osd_bg_color, 0.3);
 }
 
-  .keyboard-layout {
-    spacing: 10px;
-    padding: 10px;
+  .key-container {
+    padding: 4px;
+    spacing: 4px;
   }
 
   .keyboard-row { spacing: 15px; }
 
   .keyboard-key {
-    @include button(normal);
+    background-color: #393f3f;
     min-height: 2em;
     min-width: 2em;
-    font-size: 14pt;
-    font-weight: bold;
-    border-radius: $small_radius;
-    border: 1px solid $borders-color;
-    color: white;
+    font-size: 16pt;
+    border-radius: 3px;
+    border: 1px solid #464d4d;
+    color: #e5e5e5;
     &:focus { @include button(focus); }
     &:hover,&:checked { @include button(hover); }
     &:active { @include button(active);}
@@ -1728,11 +1745,35 @@ StScrollBar {
       color: $osd_fg_color;
       border-color: $osd_borders_color;
     }
+    &.default-key {
+      border-color: #2d3232;
+      background-color: #1d2020;
+      background-size: 20px;
+    }
+    &.enter-key {
+      border-color: #005684;
+      background-color: #006098;
+      background-image: url("resource:///org/gnome/shell/theme/key-enter.svg");
+    }
+    &.shift-key-lowercase {
+      background-image: url("resource:///org/gnome/shell/theme/key-shift.svg");
+    }
+    &.shift-key-uppercase {
+      background-image: url("resource:///org/gnome/shell/theme/key-shift-uppercase.svg");
+    }
+    &.shift-key-uppercase:latched {
+      background-image: url("resource:///org/gnome/shell/theme/key-shift-latched-uppercase.svg");
+    }
+    &.hide-key {
+      background-image: url("resource:///org/gnome/shell/theme/key-hide.svg");
+    }
+    &.layout-key {
+      background-image: url("resource:///org/gnome/shell/theme/key-layout.svg");
+    }
   }
 
   .keyboard-subkeys { //long press on a key popup
     color: white;
-    padding: 5px;
     -arrow-border-radius: 10px;
     -arrow-background-color: transparentize($osd_bg_color, 0.3);
     -arrow-border-width: 2px;
@@ -1930,7 +1971,10 @@ StScrollBar {
   text-shadow: 0px 2px 2px rgba(0,0,0,0.4);
 }
 
-.screen-shield-clock-date { font-size: 28pt; }
+.screen-shield-clock-date { 
+  font-size: 28pt;
+  font-weight: normal;
+}
 
 .screen-shield-notifications-container {
   spacing: 6px;

--- a/communitheme/key-enter.svg
+++ b/communitheme/key-enter.svg
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="svg7384"
+   height="32"
+   sodipodi:docname="key-enter.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1744"
+     inkscape:window-height="866"
+     id="namedview19"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="7.9322034"
+     inkscape:cy="14.554666"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7384" />
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient19282"
+       gradientTransform="matrix(-2.7365795,0.28202934,-0.18908311,-0.99988321,239.54008,-879.45557)">
+      <stop
+         style="stop-color:#666666;stop-opacity:1;"
+         offset="0"
+         id="stop19284" />
+    </linearGradient>
+  </defs>
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer9" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer10" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer11" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer13" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer14" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer15" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g71291" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g4953" />
+  <g
+     transform="matrix(2,0,0,2,-281.56285,-1615.0002)"
+     style="display:inline"
+     id="layer12">
+    <path
+       id="path16589"
+       d="m 148.00015,821.0002 h -1 c -0.26528,0 -0.53057,-0.093 -0.71875,-0.2812 l -3.71875,-3.7188 c 0,0 2.47917,-2.4792 3.71875,-3.7187 0.18817,-0.1882 0.45344,-0.2813 0.71875,-0.2813 h 1 v 1 c 0,0.2653 -0.0931,0.5306 -0.28125,0.7188 l -2.28125,2.2812 2.28125,2.2813 c 0.18811,0.1881 0.28129,0.4534 0.28125,0.7187 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:'Bitstream Vera Sans';-inkscape-font-specification:'Bitstream Vera Sans';text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#bebebe;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 154.0002,810 v 4.5 c 0,1.3807 -1.11929,2.5 -2.5,2.5 h -6.50005"
+       id="path16591"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/communitheme/key-hide.svg
+++ b/communitheme/key-hide.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="svg7384"
+   height="32"
+   sodipodi:docname="key-hide.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1919"
+     inkscape:window-height="1011"
+     id="namedview19"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="-12.338983"
+     inkscape:cy="14.554666"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7384" />
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient19282"
+       gradientTransform="matrix(-2.7365795,0.28202934,-0.18908311,-0.99988321,239.54008,-879.45557)">
+      <stop
+         style="stop-color:#666666;stop-opacity:1;"
+         offset="0"
+         id="stop19284" />
+    </linearGradient>
+  </defs>
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer9" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer10" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer11" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer13" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer14" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer15" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g71291" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g4953" />
+  <g
+     style="display:inline"
+     inkscape:label="go-down"
+     id="g11722"
+     transform="matrix(2,0,0,2,-362.0004,-1494)">
+    <rect
+       transform="rotate(90)"
+       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1;marker:none;enable-background:new"
+       id="rect11718"
+       y="-197.0002"
+       x="747"
+       height="16"
+       width="16" />
+    <path
+       style="display:inline;fill:#e5e5e5;fill-opacity:1;stroke:none"
+       d="m 189.0002,759.4375 -5.71875,-5.7187 C 183.08558,753.5229 183.0002,753.2556 183.0002,753 v -1 h 1 c 0.25562,0 0.52288,0.085 0.71875,0.2813 l 4.28125,4.2812 4.28125,-4.2812 C 193.47732,752.0854 193.74458,752 194.0002,752 h 1 v 1 c 0,0.2556 -0.0854,0.5229 -0.28125,0.7188 z"
+       id="path11720"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccscsccsscscc" />
+  </g>
+</svg>

--- a/communitheme/key-layout.svg
+++ b/communitheme/key-layout.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="svg7384"
+   height="32"
+   sodipodi:docname="key-layout.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1919"
+     inkscape:window-height="1011"
+     id="namedview19"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="1.220339"
+     inkscape:cy="11.842802"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7384" />
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient19282"
+       gradientTransform="matrix(-2.7365795,0.28202934,-0.18908311,-0.99988321,239.54008,-879.45557)">
+      <stop
+         style="stop-color:#666666;stop-opacity:1;"
+         offset="0"
+         id="stop19284" />
+    </linearGradient>
+  </defs>
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer9" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer10" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer11" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer13" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer14" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer15" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g71291" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g4953" />
+  <g
+     inkscape:label="preferences-desktop-locale"
+     id="g11728"
+     transform="matrix(2,0,0,2,-522.0004,-1086)"
+     style="display:inline;stroke-width:1">
+    <rect
+       style="fill:none;stroke:none;stroke-width:1"
+       id="rect11724"
+       width="16"
+       height="16"
+       x="20"
+       y="326"
+       transform="translate(241.0002,217)" />
+    <path
+       style="fill:#e5e5e5;fill-opacity:1;stroke:none;stroke-width:1"
+       d="m 265.69612,545.23396 c -3.58218,0 -4.66582,1.39975 -4.66582,1.39975 v 10.04946 c 0,0 1.08364,-1.07673 4.66582,-1.07673 2.9161,0 4.47225,1.07673 7.17818,1.07673 2.08923,0 3.19429,-1.39975 3.19429,-1.39975 v -10.04946 c 0,0 -1.14095,1.04084 -3.23018,1.04084 -3.3734,0 -3.97619,-1.04084 -7.14229,-1.04084 z m 2.93145,2.77148 c 1.32876,0 2.375,1.08037 2.375,2.4375 0,1.35713 -1.04624,2.46875 -2.375,2.46875 -1.32876,0 -2.40625,-1.11162 -2.40625,-2.46875 0,-1.35713 1.07749,-2.4375 2.40625,-2.4375 z m -4.5625,0.96875 0.96875,1.03125 -0.9375,-0.0312 0.9375,1 -0.96875,-0.0312 0.96875,1.03125 -1,-0.0312 0.0312,-1 h -0.0312 l 0.0312,-0.9688 h -0.0312 z m 4.5625,0 c -0.794,0 -1.46875,0.6578 -1.46875,1.46875 0,0.81095 0.67475,1.46875 1.46875,1.46875 0.79399,0 1.4375,-0.6578 1.4375,-1.46875 0,-0.81095 -0.64351,-1.46875 -1.4375,-1.46875 z m 4.375,0 v 1 l 0.0312,0.96875 h -0.0312 l 0.0312,1 -1,0.0312 0.96875,-1.03125 -0.96875,0.0312 0.9375,-1 -0.9375,0.0312 z m -7.9375,2.96875 0.96875,1.03125 -1,-0.0312 z m 6.9375,0 0.0312,1 -1,0.0312 z m -5.9375,1 0.96875,1.03125 -1,-0.0312 z m 4.9375,0 0.0312,1 -1,0.0312 z"
+       id="path11726"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccssccsssssssccccccccccccsssssccccccccccccccccccccccccccc" />
+  </g>
+</svg>

--- a/communitheme/key-shift-latched-uppercase.svg
+++ b/communitheme/key-shift-latched-uppercase.svg
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="svg7384"
+   height="32"
+   sodipodi:docname="key-shift-latched-uppercase.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1791"
+     inkscape:window-height="984"
+     id="namedview19"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="-0.77966097"
+     inkscape:cy="18.847458"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7384" />
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient19282"
+       gradientTransform="matrix(-2.7365795,0.28202934,-0.18908311,-0.99988321,239.54008,-879.45557)">
+      <stop
+         style="stop-color:#666666;stop-opacity:1;"
+         offset="0"
+         id="stop19284" />
+    </linearGradient>
+  </defs>
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer9" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer10" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer11" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer13" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer14" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer15" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g71291" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g4953" />
+  <g
+     transform="matrix(2,0,0,2,-282.0004,-1614.2187)"
+     style="display:inline;fill:#006098;fill-opacity:1"
+     id="layer12">
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#006098;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:new"
+       d="m 147,818 v -4 h -3.1248 l 5.125,-5.7813 5.125,5.7813 h -3.1875 v 4 z"
+       id="path16532"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path16534"
+       d="m 147,822 v -2 h 3.9377 v 2 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#006098;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:new"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/communitheme/key-shift-uppercase.svg
+++ b/communitheme/key-shift-uppercase.svg
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="svg7384"
+   height="32"
+   sodipodi:docname="key-shift-uppercase.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2160"
+     inkscape:window-height="1311"
+     id="namedview18"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="-27.898305"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7384" />
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient19282"
+       gradientTransform="matrix(-2.7365795,0.28202934,-0.18908311,-0.99988321,239.54008,-879.45557)">
+      <stop
+         style="stop-color:#666666;stop-opacity:1;"
+         offset="0"
+         id="stop19284" />
+    </linearGradient>
+  </defs>
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer9" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer10" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer11" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer13" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer14" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer15" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g71291" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g4953" />
+  <g
+     transform="matrix(2,0,0,2,-282.0008,-1614.2187)"
+     style="display:inline;fill:#006098;fill-opacity:1"
+     id="layer12">
+    <path
+       id="path16548"
+       d="m 147.0002,820 v -4 h -3.1248 l 5.125,-5.7813 5.125,5.7813 h -3.1875 v 4 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#006098;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:new"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/communitheme/key-shift.svg
+++ b/communitheme/key-shift.svg
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="svg7384"
+   height="32"
+   sodipodi:docname="key-shift.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1400"
+     inkscape:window-height="1034"
+     id="namedview4569"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="14.75"
+     inkscape:cx="1.5993763"
+     inkscape:cy="5"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7384" />
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient19282"
+       gradientTransform="matrix(-2.7365795,0.28202934,-0.18908311,-0.99988321,239.54008,-879.45557)">
+      <stop
+         style="stop-color:#666666;stop-opacity:1;"
+         offset="0"
+         id="stop19284" />
+    </linearGradient>
+  </defs>
+  <g
+     transform="translate(-143.8754,-788)"
+     style="display:inline"
+     id="layer9" />
+  <g
+     transform="translate(-143.8754,-788)"
+     style="display:inline"
+     id="layer10" />
+  <g
+     transform="translate(-143.8754,-788)"
+     id="layer11" />
+  <g
+     transform="translate(-143.8754,-788)"
+     style="display:inline"
+     id="layer13" />
+  <g
+     transform="translate(-143.8754,-788)"
+     id="layer14" />
+  <g
+     transform="translate(-143.8754,-788)"
+     style="display:inline"
+     id="layer15" />
+  <g
+     transform="translate(-143.8754,-788)"
+     style="display:inline"
+     id="g71291" />
+  <g
+     transform="translate(-143.8754,-788)"
+     style="display:inline"
+     id="g4953" />
+  <g
+     transform="matrix(2,0,0,2,-282.0008,-1614.2187)"
+     style="display:inline"
+     id="layer12">
+    <path
+       id="path16548"
+       d="m 147.0002,820 v -4 h -3.1248 l 5.125,-5.7813 5.125,5.7813 h -3.1875 v 4 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:new"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-gnome-shell-communitheme (18.04~wip1) artful; urgency=medium
+gnome-shell-communitheme (18.04~wip1) bionic; urgency=medium
 
   * Initial release
 

--- a/upstream/README
+++ b/upstream/README
@@ -1,12 +1,9 @@
 Summary
 -------
 
-* Do not edit the CSS directly, edit the source SCSS files and process them with SASS (running
-  `make` should do that when you have the required software installed, as described below;
-  run `./parse-sass.sh` manually if it doesn't)
-* Most SASS preprocessors should produce similar results, however the build system
-  integration and 'parse-sass.sh' script use sassc. You should be able to install
-  it with `pkcon install sassc` or your distribution's package manager.
+* Do not edit the CSS directly, edit the source SCSS files and the CSS files will be generated
+  automatically when building with meson + ninja and left inside the build directory to be
+  incorporated into the gresource XML (you'll need to have sassc installed).
 
 How to tweak the theme
 ----------------------
@@ -31,4 +28,4 @@ _common.scss        - actual definitions of style for each widget. This is where
                       your changes.
                       
 You can read about SASS at http://sass-lang.com/documentation/. Once you make your changes to the
-_common.scss file, you can either run make or the ./parse-sass.sh script.
+_common.scss file, you can run ninja to generate the final CSS files.

--- a/upstream/key-enter.svg
+++ b/upstream/key-enter.svg
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="svg7384"
+   height="32"
+   sodipodi:docname="key-enter.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1744"
+     inkscape:window-height="866"
+     id="namedview19"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="7.9322034"
+     inkscape:cy="14.554666"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7384" />
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient19282"
+       gradientTransform="matrix(-2.7365795,0.28202934,-0.18908311,-0.99988321,239.54008,-879.45557)">
+      <stop
+         style="stop-color:#666666;stop-opacity:1;"
+         offset="0"
+         id="stop19284" />
+    </linearGradient>
+  </defs>
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer9" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer10" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer11" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer13" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer14" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer15" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g71291" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g4953" />
+  <g
+     transform="matrix(2,0,0,2,-281.56285,-1615.0002)"
+     style="display:inline"
+     id="layer12">
+    <path
+       id="path16589"
+       d="m 148.00015,821.0002 h -1 c -0.26528,0 -0.53057,-0.093 -0.71875,-0.2812 l -3.71875,-3.7188 c 0,0 2.47917,-2.4792 3.71875,-3.7187 0.18817,-0.1882 0.45344,-0.2813 0.71875,-0.2813 h 1 v 1 c 0,0.2653 -0.0931,0.5306 -0.28125,0.7188 l -2.28125,2.2812 2.28125,2.2813 c 0.18811,0.1881 0.28129,0.4534 0.28125,0.7187 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:'Bitstream Vera Sans';-inkscape-font-specification:'Bitstream Vera Sans';text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#bebebe;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 154.0002,810 v 4.5 c 0,1.3807 -1.11929,2.5 -2.5,2.5 h -6.50005"
+       id="path16591"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/upstream/key-hide.svg
+++ b/upstream/key-hide.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="svg7384"
+   height="32"
+   sodipodi:docname="key-hide.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1919"
+     inkscape:window-height="1011"
+     id="namedview19"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="-12.338983"
+     inkscape:cy="14.554666"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7384" />
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient19282"
+       gradientTransform="matrix(-2.7365795,0.28202934,-0.18908311,-0.99988321,239.54008,-879.45557)">
+      <stop
+         style="stop-color:#666666;stop-opacity:1;"
+         offset="0"
+         id="stop19284" />
+    </linearGradient>
+  </defs>
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer9" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer10" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer11" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer13" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer14" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer15" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g71291" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g4953" />
+  <g
+     style="display:inline"
+     inkscape:label="go-down"
+     id="g11722"
+     transform="matrix(2,0,0,2,-362.0004,-1494)">
+    <rect
+       transform="rotate(90)"
+       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1;marker:none;enable-background:new"
+       id="rect11718"
+       y="-197.0002"
+       x="747"
+       height="16"
+       width="16" />
+    <path
+       style="display:inline;fill:#e5e5e5;fill-opacity:1;stroke:none"
+       d="m 189.0002,759.4375 -5.71875,-5.7187 C 183.08558,753.5229 183.0002,753.2556 183.0002,753 v -1 h 1 c 0.25562,0 0.52288,0.085 0.71875,0.2813 l 4.28125,4.2812 4.28125,-4.2812 C 193.47732,752.0854 193.74458,752 194.0002,752 h 1 v 1 c 0,0.2556 -0.0854,0.5229 -0.28125,0.7188 z"
+       id="path11720"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccscsccsscscc" />
+  </g>
+</svg>

--- a/upstream/key-layout.svg
+++ b/upstream/key-layout.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="svg7384"
+   height="32"
+   sodipodi:docname="key-layout.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1919"
+     inkscape:window-height="1011"
+     id="namedview19"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="1.220339"
+     inkscape:cy="11.842802"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7384" />
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient19282"
+       gradientTransform="matrix(-2.7365795,0.28202934,-0.18908311,-0.99988321,239.54008,-879.45557)">
+      <stop
+         style="stop-color:#666666;stop-opacity:1;"
+         offset="0"
+         id="stop19284" />
+    </linearGradient>
+  </defs>
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer9" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer10" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer11" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer13" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer14" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer15" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g71291" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g4953" />
+  <g
+     inkscape:label="preferences-desktop-locale"
+     id="g11728"
+     transform="matrix(2,0,0,2,-522.0004,-1086)"
+     style="display:inline;stroke-width:1">
+    <rect
+       style="fill:none;stroke:none;stroke-width:1"
+       id="rect11724"
+       width="16"
+       height="16"
+       x="20"
+       y="326"
+       transform="translate(241.0002,217)" />
+    <path
+       style="fill:#e5e5e5;fill-opacity:1;stroke:none;stroke-width:1"
+       d="m 265.69612,545.23396 c -3.58218,0 -4.66582,1.39975 -4.66582,1.39975 v 10.04946 c 0,0 1.08364,-1.07673 4.66582,-1.07673 2.9161,0 4.47225,1.07673 7.17818,1.07673 2.08923,0 3.19429,-1.39975 3.19429,-1.39975 v -10.04946 c 0,0 -1.14095,1.04084 -3.23018,1.04084 -3.3734,0 -3.97619,-1.04084 -7.14229,-1.04084 z m 2.93145,2.77148 c 1.32876,0 2.375,1.08037 2.375,2.4375 0,1.35713 -1.04624,2.46875 -2.375,2.46875 -1.32876,0 -2.40625,-1.11162 -2.40625,-2.46875 0,-1.35713 1.07749,-2.4375 2.40625,-2.4375 z m -4.5625,0.96875 0.96875,1.03125 -0.9375,-0.0312 0.9375,1 -0.96875,-0.0312 0.96875,1.03125 -1,-0.0312 0.0312,-1 h -0.0312 l 0.0312,-0.9688 h -0.0312 z m 4.5625,0 c -0.794,0 -1.46875,0.6578 -1.46875,1.46875 0,0.81095 0.67475,1.46875 1.46875,1.46875 0.79399,0 1.4375,-0.6578 1.4375,-1.46875 0,-0.81095 -0.64351,-1.46875 -1.4375,-1.46875 z m 4.375,0 v 1 l 0.0312,0.96875 h -0.0312 l 0.0312,1 -1,0.0312 0.96875,-1.03125 -0.96875,0.0312 0.9375,-1 -0.9375,0.0312 z m -7.9375,2.96875 0.96875,1.03125 -1,-0.0312 z m 6.9375,0 0.0312,1 -1,0.0312 z m -5.9375,1 0.96875,1.03125 -1,-0.0312 z m 4.9375,0 0.0312,1 -1,0.0312 z"
+       id="path11726"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccssccsssssssccccccccccccsssssccccccccccccccccccccccccccc" />
+  </g>
+</svg>

--- a/upstream/key-shift-latched-uppercase.svg
+++ b/upstream/key-shift-latched-uppercase.svg
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="svg7384"
+   height="32"
+   sodipodi:docname="key-shift-latched-uppercase.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1791"
+     inkscape:window-height="984"
+     id="namedview19"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="-0.77966097"
+     inkscape:cy="18.847458"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7384" />
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient19282"
+       gradientTransform="matrix(-2.7365795,0.28202934,-0.18908311,-0.99988321,239.54008,-879.45557)">
+      <stop
+         style="stop-color:#666666;stop-opacity:1;"
+         offset="0"
+         id="stop19284" />
+    </linearGradient>
+  </defs>
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer9" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer10" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer11" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer13" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer14" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer15" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g71291" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g4953" />
+  <g
+     transform="matrix(2,0,0,2,-282.0004,-1614.2187)"
+     style="display:inline;fill:#006098;fill-opacity:1"
+     id="layer12">
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#006098;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:new"
+       d="m 147,818 v -4 h -3.1248 l 5.125,-5.7813 5.125,5.7813 h -3.1875 v 4 z"
+       id="path16532"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path16534"
+       d="m 147,822 v -2 h 3.9377 v 2 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#006098;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:new"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/upstream/key-shift-uppercase.svg
+++ b/upstream/key-shift-uppercase.svg
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="svg7384"
+   height="32"
+   sodipodi:docname="key-shift-uppercase.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2160"
+     inkscape:window-height="1311"
+     id="namedview18"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="-27.898305"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7384" />
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient19282"
+       gradientTransform="matrix(-2.7365795,0.28202934,-0.18908311,-0.99988321,239.54008,-879.45557)">
+      <stop
+         style="stop-color:#666666;stop-opacity:1;"
+         offset="0"
+         id="stop19284" />
+    </linearGradient>
+  </defs>
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer9" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer10" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer11" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer13" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer14" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer15" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g71291" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g4953" />
+  <g
+     transform="matrix(2,0,0,2,-282.0008,-1614.2187)"
+     style="display:inline;fill:#006098;fill-opacity:1"
+     id="layer12">
+    <path
+       id="path16548"
+       d="m 147.0002,820 v -4 h -3.1248 l 5.125,-5.7813 5.125,5.7813 h -3.1875 v 4 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#006098;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:new"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/upstream/key-shift.svg
+++ b/upstream/key-shift.svg
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="svg7384"
+   height="32"
+   sodipodi:docname="key-shift.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1400"
+     inkscape:window-height="1034"
+     id="namedview4569"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="14.75"
+     inkscape:cx="1.5993763"
+     inkscape:cy="5"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7384" />
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient19282"
+       gradientTransform="matrix(-2.7365795,0.28202934,-0.18908311,-0.99988321,239.54008,-879.45557)">
+      <stop
+         style="stop-color:#666666;stop-opacity:1;"
+         offset="0"
+         id="stop19284" />
+    </linearGradient>
+  </defs>
+  <g
+     transform="translate(-143.8754,-788)"
+     style="display:inline"
+     id="layer9" />
+  <g
+     transform="translate(-143.8754,-788)"
+     style="display:inline"
+     id="layer10" />
+  <g
+     transform="translate(-143.8754,-788)"
+     id="layer11" />
+  <g
+     transform="translate(-143.8754,-788)"
+     style="display:inline"
+     id="layer13" />
+  <g
+     transform="translate(-143.8754,-788)"
+     id="layer14" />
+  <g
+     transform="translate(-143.8754,-788)"
+     style="display:inline"
+     id="layer15" />
+  <g
+     transform="translate(-143.8754,-788)"
+     style="display:inline"
+     id="g71291" />
+  <g
+     transform="translate(-143.8754,-788)"
+     style="display:inline"
+     id="g4953" />
+  <g
+     transform="matrix(2,0,0,2,-282.0008,-1614.2187)"
+     style="display:inline"
+     id="layer12">
+    <path
+       id="path16548"
+       d="m 147.0002,820 v -4 h -3.1248 l 5.125,-5.7813 5.125,5.7813 h -3.1875 v 4 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:new"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/upstream/meson.build
+++ b/upstream/meson.build
@@ -1,0 +1,25 @@
+theme_sources = files([
+  'gnome-shell-high-contrast.scss',
+  'gnome-shell.scss',
+  'gnome-shell-sass/_colors.scss',
+  'gnome-shell-sass/_common.scss',
+  'gnome-shell-sass/_drawing.scss',
+  'gnome-shell-sass/_high-contrast-colors.scss'
+])
+
+styles = [
+  'gnome-shell-high-contrast',
+  'gnome-shell'
+]
+
+theme_deps = []
+
+foreach style: styles
+  theme_deps += custom_target('style-' + style,
+                              input: '@0@.scss'.format(style),
+                              output: '@0@.css'.format(style),
+                              command: [
+                                sassc, '-a', '@INPUT@', '@OUTPUT@'
+                              ],
+                              depend_files: theme_sources)
+endforeach


### PR DESCRIPTION
OSK classes have been impacted. Use the upstream colors when applicable
for now and use upstream svg.
