### PR TITLE
no overview background and round thumbnails

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1576,7 +1576,7 @@ StScrollBar {
 
 %overview-panel {
   color: $osd_fg_color;
-  background-color: none; 
+  background-color: transparentize($panel_bg_color,0.5);
   //transparentize($osd_fg_color,0.9) 
   //border: 1px solid $osd_borders_color;
   border: none;

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1562,6 +1562,7 @@ StScrollBar {
   }
   .workspace-thumbnail-indicator {
     border: 4px solid $selected_bg_color;
+    border-radius: $medium_radius;
     padding: 1px;
   }
 
@@ -1575,8 +1576,10 @@ StScrollBar {
 
 %overview-panel {
   color: $osd_fg_color;
-  background-color: $_dialog_bg_color;
-  border: 1px solid $osd_borders_color;
+  background-color: none; 
+  //transparentize($osd_fg_color,0.9) 
+  //border: 1px solid $osd_borders_color;
+  border: none;
 }
 
 %status_text {


### PR DESCRIPTION
Tried some stuff for https://github.com/ubuntu/gnome-shell-communitheme/issues/76

- I completely removed the background from the workspace overview panel
- and added the round border for the thumbnails

![screenshot from 2018-03-30 01-06-43](https://user-images.githubusercontent.com/15329494/38117672-abdbffe0-33b6-11e8-8c3e-81b88cd0f91f.png)


@clobrano @madsrh @didrocks  what do you think? :) I like it - could be a bit too much  or... too little :}