### PR TITLE
White notifications & transparent white overview window clone border

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1281,13 +1281,13 @@ StScrollBar {
   }
 
   .window-clone-border {
-    $_bg: $selected_bg_color;
-    border: 4px solid $_bg;
+    $_bg: transparentize(white,0.6);
+    border: 5px solid $_bg;
     border-radius: $medium_radius;
     // For window decorations with round corners we can't match
     // the exact shape when the window is scaled. So apply a shadow
     // to fix that case
-    //box-shadow: inset 0px 0px 0px 2px $_bg;
+    box-shadow: inset 0px 0px 5px 0px $_bg;
   }
   .window-caption {
     spacing: 25px;

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1596,33 +1596,71 @@ StScrollBar {
   .notification-banner {
     font-size: 11pt;
     width: 34em;
+    min-height: 64px;
     margin: 5px;
-    border-radius: $medium_radius;
-    color: $osd_fg_color;
-    background-color: $osd_bg_color;
-    border: 1px solid $osd_borders_color;
-    //box-shadow: 0 1px 4px black;
-    box-shadow: none;
-    &:hover, &:focus { background-color: opacify(mix($osd_bg_color, $base_hover_color), 1); }
-
-    .notification-icon { padding: 5px; }
-    .notification-content { padding: 5px; spacing: 5px; }
-    .secondary-icon { icon-size: 1.09em; }
-    .notification-actions {
-      background-color: $osd_borders_color; // $borders_color;
-      padding-top: 1px;
-      spacing: 1px;
-    }
-    .notification-button {
-      // padding: 4px 4px 5px;
-      min-height: 22px; // make just a little taller
-      padding: 4px 32px;
-      background-color: darken($_dialog_bg_color,5%);
-      &:first-child { border-radius: 0 0 0 6px; }
-      &:last-child { border-radius: 0 0 6px 0; }
-      &:hover, &:focus { background-color: darken($_dialog_bg_color,2%); }
-      &:active { background-color: darken($_dialog_bg_color, 5%); }
-    }
+    border-radius: $medium-radius;
+    color: $inkstone;
+    background-color: white;
+    border: none;
+    //box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 3px 3px rgba(0, 0, 0, 0.345);
+    box-shadow: 0 2px 5px transparentize(black, 0.75);
+    color: $inkstone;
+    &, &:active { .message-title { color: $inkstone; } }
+    &, &:active { .message-content { color: $slate; } }
+  }
+  
+  .notification-banner:hover {
+    background-color: white;
+  }
+  
+  .notification-banner:focus {
+    background-color: white;
+  }
+  
+  .notification-banner .notification-icon {
+    padding: 5px;
+  }
+  
+  .notification-banner .notification-content {
+    padding: 5px;
+    spacing: 5px;
+  }
+  
+  .notification-banner .secondary-icon {
+    icon-size: 1.14286em;
+  }
+  
+  .notification-banner .notification-actions {
+    background-color: transparent;
+    padding-top: 0;
+    border-top: 1px solid rgba(0, 0, 0, 0.12);
+    spacing: 1px;
+  }
+  
+  .notification-banner .notification-button {
+    min-height: 35px;
+    padding: 0 16px;
+    background-color: transparent;
+    color: rgba(0, 0, 0, 0.54);
+    font-weight: 500;
+  }
+  
+  .notification-banner .notification-button:first-child {
+    border-radius: 0 0 0 2px;
+  }
+  
+  .notification-banner .notification-button:last-child {
+    border-radius: 0 0 2px 0;
+  }
+  
+  .notification-banner .notification-button:hover, .notification-banner .notification-buttonfocus {
+    background-color: rgba(0, 0, 0, 0.12);
+    color: rgba(0, 0, 0, 0.87);
+  }
+  
+  .notification-banner .notification-button:active {
+    background-color: rgba(0, 0, 0, 0.26);
+    color: rgba(0, 0, 0, 0.87);
   }
   .summary-source-counter {
     font-size: 10pt;

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1602,8 +1602,7 @@ StScrollBar {
     color: $inkstone;
     background-color: white;
     border: none;
-    //box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 3px 3px rgba(0, 0, 0, 0.345);
-    box-shadow: 0 2px 5px transparentize(black, 0.75);
+    box-shadow: 0 3px 9px 1px transparentize(black, 0.5);
     color: $inkstone;
     &, &:active { .message-title { color: $inkstone; } }
     &, &:active { .message-content { color: $slate; } }

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1282,12 +1282,12 @@ StScrollBar {
 
   .window-clone-border {
     $_bg: $selected_bg_color;
-    border: 2px solid $_bg;
+    border: 4px solid $_bg;
     border-radius: $medium_radius;
     // For window decorations with round corners we can't match
     // the exact shape when the window is scaled. So apply a shadow
     // to fix that case
-    box-shadow: inset 0px 0px 0px 4px $_bg;
+    //box-shadow: inset 0px 0px 0px 2px $_bg;
   }
   .window-caption {
     spacing: 25px;

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1211,7 +1211,7 @@ StScrollBar {
 .window-close {
   transition-duration: 100ms;
   background-image: url("close-window.svg");
-  background-size: 28px;
+  background-size: 32px;
   height: 32px;
   width: 32px;
   -shell-close-overlap: 16px;

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1213,7 +1213,7 @@ StScrollBar {
   background-size: 32px;
   height: 32px;
   width: 32px;
-  -shell-close-overlap: 16px;
+  -shell-close-overlap: 13px;
 
   &:hover { background-image: url("close-window-hover.svg"); }
   &:active { background-image: url("close-window-active.svg"); }


### PR DESCRIPTION
White notifications as a solution to the current readability problem of dark notifications on the dark GTK3 headerbars as discussed here: https://github.com/ubuntu/gnome-shell-communitheme/issues/89