### PR TITLE
Renamed XDG_CURRENT_DESKTOP because regexes seem to be hard

### DIFF
--- a/session/ubuntu-communitheme-xorg.desktop
+++ b/session/ubuntu-communitheme-xorg.desktop
@@ -5,5 +5,5 @@ Exec=env GNOME_SHELL_SESSION_MODE=ubuntu-communitheme gnome-session --session=ub
 TryExec=gnome-shell
 Icon=
 Type=Application
-DesktopNames=ubuntu-communitheme:ubuntu:GNOME
+DesktopNames=ubuntu:GNOME
 X-Ubuntu-Gettext-Domain=gnome-session-3.0

--- a/session/ubuntu-communitheme.desktop
+++ b/session/ubuntu-communitheme.desktop
@@ -5,5 +5,5 @@ Exec=env GNOME_SHELL_SESSION_MODE=ubuntu-communitheme gnome-session --session=ub
 TryExec=gnome-shell
 Icon=
 Type=Application
-DesktopNames=ubuntu-communitheme:ubuntu:GNOME
+DesktopNames=ubuntu:GNOME
 X-Ubuntu-Gettext-Domain=gnome-session-3.0


### PR DESCRIPTION
Fixes https://github.com/ubuntu/gnome-shell-communitheme/issues/95

It seems dropbox requires `XDG_CURRENT_DESKTOP` to be EXACTLY `Unity` or `ubuntu:gnome` in order to use the appindicator api (KStatusNotifierItem) correctly.

@didrocks any idea if this will break something else? I wouldn't think so since the communitheme session is the `ubuntu:gnome` session, except for the themes and some gsettings?..