### PR TITLE
Fixed readability of top panel text and icons

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -5,7 +5,7 @@ $cakeisalie: "This stylesheet is generated, DO NOT EDIT";
 /* #{$cakeisalie} */
 $panel-corner-radius: 0; // 6px;
 
-$panel-alpha-value: 0.8;
+$panel-alpha-value: 0.7;
 $dash-alpha-value: 0.7;
 $dash-opaque-alpha-value: 0.0;
 $popover-alpha-value: 0.015;
@@ -801,8 +801,8 @@ StScrollBar {
     -natural-hpadding: 12px;
     -minimum-hpadding: 6px;
     font-weight: 450;
-    color: $_fg;
-    text-shadow: none;
+    color: darken($_fg, 5%);
+    text-shadow: 0px 1px 4px rgba(0, 0, 0, 0.6);
     transition-duration: 100ms;
 
     .app-menu-icon {
@@ -814,9 +814,9 @@ StScrollBar {
 
     .system-status-icon,
     .app-menu-icon > StIcon,
-    //.popup-menu-arrow {
-    //  icon-shadow: 0px 1px 2px rgba(0, 0, 0, 0.7);
-    //}
+    .popup-menu-arrow {
+      icon-shadow: 0px 1px 4px rgba(0, 0, 0, 0.6);
+    }
 
     &:hover {
       color: $hover_fg_color;


### PR DESCRIPTION
- slightly reduced text color by 5% in normal state
- added text and icon shadow in normal state
- reduced top panel and dock transparency by 10% (0.8 -> 0.7)

closes #100 