### PR TITLE
Use less orange for alt-tab and workspace thumbnails

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -665,7 +665,9 @@ StScrollBar {
   }
 
   .switcher-list .item-box:selected {
-    background-color: $selected_bg_color;
+    background-color: $base_hover_color;
+    border: 2px solid $selected_bg_color;
+    border-radius: $small_radius;
     color: $selected_fg_color;
   }
 
@@ -1541,13 +1543,14 @@ StScrollBar {
     visible-width: 32px; //amount visible before hover
     spacing: 11px;
     padding: 8px;
-    border-radius: 9px 0 0 9px;
+    border-radius: $medium_radius 0 0 $medium_radius;
     //border-width: 1px 0 1px 1px; //fixme: can't have non unoform borders :(
-    &:rtl { border-radius: 0 9px 9px 0;}
+    &:rtl { border-radius: 0 $medium_radius $medium_radius 0;}
   }
   .workspace-thumbnail-indicator {
-    border: 4px solid $selected_bg_color;
-    padding: 1px;
+    border: 0px solid $selected_bg_color;
+    border-left-width: 2px;
+    padding: 4px;
   }
 
   //Some hacks I don't even

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1298,15 +1298,13 @@ StScrollBar {
     border-color: $osd_borders_color;
     color: $osd_fg_color;
     background-color: $osd_bg_color;
-
-    &, &:focus { padding: 7px 9px; }
+    padding: 6px 4px;
 
     &:focus {
-      border-width: 1px;
       border-color: $selected_bg_color;
     }
 
-    .search-entry-icon { icon-size: 1em; padding: 0 4px; color: transparentize($fg_color,.3); }
+    .search-entry-icon { icon-size: 1em; padding: 0 6px; color: transparentize($fg_color,.3); }
 
     &:hover, &:focus {
       .search-entry-icon { color: $fg_color; }


### PR DESCRIPTION
- The selected app in the alt-tab window uses an orange border with a slightly lightened background ($base_hover_color)
- The workspace thumbnail in the overview uses a 2px wide orange line instead of a thick border

Closes #112 
Closes #113