### PR TITLE
Implemented new gnome-shell dock and top panel transparencies

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -6,10 +6,10 @@ $cakeisalie: "This stylesheet is generated, DO NOT EDIT";
 $panel-corner-radius: 0; // 6px;
 
 $panel-alpha-value: 0.6;
-$panel_opaque_value: 0.1;
+$panel_opaque_value: 0.15;
 
 $dash-alpha-value: 0.6;
-$dash-opaque-alpha-value: 0.1;
+$dash-opaque-alpha-value: 0.15;
 
 $popover-alpha-value: 0.015;
 

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -5,15 +5,17 @@ $cakeisalie: "This stylesheet is generated, DO NOT EDIT";
 /* #{$cakeisalie} */
 $panel-corner-radius: 0; // 6px;
 
-$panel-alpha-value: 0.7;
-$dash-alpha-value: 0.7;
-$dash-opaque-alpha-value: 0.0;
+$panel-alpha-value: 0.6;
+$panel_opaque_value: 0.4;
+
+$dash-alpha-value: 0.6;
+$dash-opaque-alpha-value: 0.4;
+
 $popover-alpha-value: 0.015;
 
 $small_radius: 4px;
 $medium_radius: 6px;
 $large_radius: 12px;
-
 
 /* Copyright 2009, 2015 Red Hat, Inc.
  *
@@ -767,8 +769,9 @@ StScrollBar {
 /* TOP BAR */
 
 #panel {
-  $_fg: $panel_fg_color;
+  $_fg: darken($panel_fg_color, 5%);
   background-color: transparentize($panel_bg_color, $panel-alpha-value);
+
   /* transition from solid to transparent */
   transition-duration: 500ms;
   font-weight: 450;
@@ -805,8 +808,8 @@ StScrollBar {
     -natural-hpadding: 12px;
     -minimum-hpadding: 6px;
     font-weight: 450;
-    color: darken($_fg, 5%);
-    text-shadow: 0px 1px 4px rgba(0, 0, 0, 0.6);
+    color: $_fg;
+    text-shadow: none;
     transition-duration: 100ms;
 
     .app-menu-icon {
@@ -819,18 +822,16 @@ StScrollBar {
     .system-status-icon,
     .app-menu-icon > StIcon,
     .popup-menu-arrow {
-      icon-shadow: 0px 1px 4px rgba(0, 0, 0, 0.6);
+      icon-shadow: none;
     }
 
     &:hover {
       color: $hover_fg_color;
-      text-shadow: 0px 1px 4px rgba(0, 0, 0, 1);
+      text-shadow: none;
 
       .system-status-icon,
       .app-menu-icon > StIcon,
-      .popup-menu-arrow {
-        icon-shadow: 0px 1px 4px rgba(0, 0, 0, 1);
-      }
+      .popup-menu-arrow { icon-shadow: none; }
     }
 
     &:active, &:overview, &:focus, &:checked {
@@ -840,7 +841,7 @@ StScrollBar {
       box-shadow: inset 0px -2px $selected_bg_color;
       color: lighten($_fg,10%);
 
-      & > .system-status-icon { icon-shadow: none; /*black 0 2px 2px;*/ }
+      & > .system-status-icon { icon-shadow: none; }
     }
 
     .system-status-icon { icon-size: 1.09em; padding: 0 5px; }
@@ -865,8 +866,8 @@ StScrollBar {
   .screencast-indicator { color: $warning_color; }
 
   &.solid {
-    background-color: $panel_bg_color;
-    // box-shadow: inset 0 -1px _border_color($panel_bg_color);
+    background-color: transparentize($panel_bg_color, $panel_opaque_value);;
+
     /* transition from transparent to solid */
     box-shadow: none;
     transition-duration: 500ms;
@@ -886,9 +887,7 @@ StScrollBar {
 
     .system-status-icon,
     .app-menu-icon > StIcon,
-    .popup-menu-arrow {
-      icon-shadow: none;
-    }
+    .popup-menu-arrow { icon-shadow: none; }
   }
 }
 

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -6,10 +6,10 @@ $cakeisalie: "This stylesheet is generated, DO NOT EDIT";
 $panel-corner-radius: 0; // 6px;
 
 $panel-alpha-value: 0.6;
-$panel_opaque_value: 0.4;
+$panel_opaque_value: 0.2;
 
 $dash-alpha-value: 0.6;
-$dash-opaque-alpha-value: 0.4;
+$dash-opaque-alpha-value: 0.2;
 
 $popover-alpha-value: 0.015;
 
@@ -809,7 +809,7 @@ StScrollBar {
     -minimum-hpadding: 6px;
     font-weight: 450;
     color: $_fg;
-    text-shadow: none;
+    text-shadow: -1px 0 rgba(0, 0, 0, 0.6), 1px 0 rgba(0, 0, 0, 0.6), 0 -1px rgba(0, 0, 0, 0.6), 0 1px rgba(0, 0, 0, 0.6);
     transition-duration: 100ms;
 
     .app-menu-icon {
@@ -822,16 +822,18 @@ StScrollBar {
     .system-status-icon,
     .app-menu-icon > StIcon,
     .popup-menu-arrow {
-      icon-shadow: none;
+      icon-shadow: -1px 0 rgba(0, 0, 0, 0.6), 1px 0 rgba(0, 0, 0, 0.6), 0 -1px rgba(0, 0, 0, 0.6), 0 1px rgba(0, 0, 0, 0.6);
     }
 
     &:hover {
       color: $hover_fg_color;
-      text-shadow: none;
+      text-shadow: -1px 0 rgba(0, 0, 0, 0.6), 1px 0 rgba(0, 0, 0, 0.6), 0 -1px rgba(0, 0, 0, 0.6), 0 1px rgba(0, 0, 0, 0.6);
 
       .system-status-icon,
       .app-menu-icon > StIcon,
-      .popup-menu-arrow { icon-shadow: none; }
+      .popup-menu-arrow {
+        icon-shadow: -1px 0 rgba(0, 0, 0, 0.6), 1px 0 rgba(0, 0, 0, 0.6), 0 -1px rgba(0, 0, 0, 0.6), 0 1px rgba(0, 0, 0, 0.6);
+      }
     }
 
     &:active, &:overview, &:focus, &:checked {
@@ -841,7 +843,9 @@ StScrollBar {
       box-shadow: inset 0px -2px $selected_bg_color;
       color: lighten($_fg,10%);
 
-      & > .system-status-icon { icon-shadow: none; }
+      & > .system-status-icon {
+        icon-shadow: -1px 0 rgba(0, 0, 0, 0.6), 1px 0 rgba(0, 0, 0, 0.6), 0 -1px rgba(0, 0, 0, 0.6), 0 1px rgba(0, 0, 0, 0.6);
+      }
     }
 
     .system-status-icon { icon-size: 1.09em; padding: 0 5px; }
@@ -878,7 +882,7 @@ StScrollBar {
 
     .panel-button {
       color: $_fg;
-      text-shadow: none;
+      text-shadow: -1px 0 black, 1px 0 black, 0 -1px black, 0 1px black;
 
       &:hover, &:active, &:overview, &:focus, &:checked {
         color: $hover_fg_color;
@@ -887,7 +891,9 @@ StScrollBar {
 
     .system-status-icon,
     .app-menu-icon > StIcon,
-    .popup-menu-arrow { icon-shadow: none; }
+    .popup-menu-arrow {
+      icon-shadow: -1px 0 rgba(0, 0, 0, 0.6), 1px 0 rgba(0, 0, 0, 0.6), 0 -1px rgba(0, 0, 0, 0.6), 0 1px rgba(0, 0, 0, 0.6);
+    }
   }
 }
 

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -6,10 +6,10 @@ $cakeisalie: "This stylesheet is generated, DO NOT EDIT";
 $panel-corner-radius: 0; // 6px;
 
 $panel-alpha-value: 0.6;
-$panel_opaque_value: 0.2;
+$panel_opaque_value: 0.1;
 
 $dash-alpha-value: 0.6;
-$dash-opaque-alpha-value: 0.2;
+$dash-opaque-alpha-value: 0.1;
 
 $popover-alpha-value: 0.015;
 
@@ -809,7 +809,7 @@ StScrollBar {
     -minimum-hpadding: 6px;
     font-weight: 450;
     color: $_fg;
-    text-shadow: -1px 0 rgba(0, 0, 0, 0.6), 1px 0 rgba(0, 0, 0, 0.6), 0 -1px rgba(0, 0, 0, 0.6), 0 1px rgba(0, 0, 0, 0.6);
+    text-shadow: 0px 1px 4px rgba(0, 0, 0, 0.6);
     transition-duration: 100ms;
 
     .app-menu-icon {
@@ -822,17 +822,17 @@ StScrollBar {
     .system-status-icon,
     .app-menu-icon > StIcon,
     .popup-menu-arrow {
-      icon-shadow: -1px 0 rgba(0, 0, 0, 0.6), 1px 0 rgba(0, 0, 0, 0.6), 0 -1px rgba(0, 0, 0, 0.6), 0 1px rgba(0, 0, 0, 0.6);
+      icon-shadow: 0px 1px 4px rgba(0, 0, 0, 0.6);
     }
 
     &:hover {
       color: $hover_fg_color;
-      text-shadow: -1px 0 rgba(0, 0, 0, 0.6), 1px 0 rgba(0, 0, 0, 0.6), 0 -1px rgba(0, 0, 0, 0.6), 0 1px rgba(0, 0, 0, 0.6);
+      text-shadow: 0px 1px 4px rgba(0, 0, 0, 1);
 
       .system-status-icon,
       .app-menu-icon > StIcon,
       .popup-menu-arrow {
-        icon-shadow: -1px 0 rgba(0, 0, 0, 0.6), 1px 0 rgba(0, 0, 0, 0.6), 0 -1px rgba(0, 0, 0, 0.6), 0 1px rgba(0, 0, 0, 0.6);
+        icon-shadow: 0px 1px 4px rgba(0, 0, 0, 1);
       }
     }
 
@@ -844,7 +844,7 @@ StScrollBar {
       color: lighten($_fg,10%);
 
       & > .system-status-icon {
-        icon-shadow: -1px 0 rgba(0, 0, 0, 0.6), 1px 0 rgba(0, 0, 0, 0.6), 0 -1px rgba(0, 0, 0, 0.6), 0 1px rgba(0, 0, 0, 0.6);
+        icon-shadow: 0px 1px 4px rgba(0, 0, 0, 1);
       }
     }
 
@@ -882,7 +882,7 @@ StScrollBar {
 
     .panel-button {
       color: $_fg;
-      text-shadow: -1px 0 black, 1px 0 black, 0 -1px black, 0 1px black;
+      text-shadow: none;
 
       &:hover, &:active, &:overview, &:focus, &:checked {
         color: $hover_fg_color;
@@ -892,7 +892,7 @@ StScrollBar {
     .system-status-icon,
     .app-menu-icon > StIcon,
     .popup-menu-arrow {
-      icon-shadow: -1px 0 rgba(0, 0, 0, 0.6), 1px 0 rgba(0, 0, 0, 0.6), 0 -1px rgba(0, 0, 0, 0.6), 0 1px rgba(0, 0, 0, 0.6);
+      icon-shadow: none;
     }
   }
 }

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -771,7 +771,6 @@ StScrollBar {
 #panel {
   $_fg: darken($panel_fg_color, 5%);
   background-color: transparentize($panel_bg_color, $panel-alpha-value);
-  box-shadow: inset 0 -1px 2px -1px rgba(0, 0, 0, 0.5);
 
   /* transition from solid to transparent */
   transition-duration: 500ms;
@@ -872,7 +871,6 @@ StScrollBar {
 
   &.solid {
     background-color: transparentize($panel_bg_color, $panel_opaque_value);
-    box-shadow: inset 0 -1px 2px -1px rgba(0, 0, 0, 0.7) !important;
 
     /* transition from transparent to solid */
     box-shadow: none;

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -6,10 +6,10 @@ $cakeisalie: "This stylesheet is generated, DO NOT EDIT";
 $panel-corner-radius: 0; // 6px;
 
 $panel-alpha-value: 0.6;
-$panel_opaque_value: 0.15;
+$panel_opaque_value: 0.13;
 
 $dash-alpha-value: 0.6;
-$dash-opaque-alpha-value: 0.15;
+$dash-opaque-alpha-value: 0.13;
 
 $popover-alpha-value: 0.015;
 
@@ -771,6 +771,7 @@ StScrollBar {
 #panel {
   $_fg: darken($panel_fg_color, 5%);
   background-color: transparentize($panel_bg_color, $panel-alpha-value);
+  box-shadow: inset 0 -1px 2px -1px rgba(0, 0, 0, 0.5);
 
   /* transition from solid to transparent */
   transition-duration: 500ms;
@@ -870,7 +871,8 @@ StScrollBar {
   .screencast-indicator { color: $warning_color; }
 
   &.solid {
-    background-color: transparentize($panel_bg_color, $panel_opaque_value);;
+    background-color: transparentize($panel_bg_color, $panel_opaque_value);
+    box-shadow: inset 0 -1px 2px -1px rgba(0, 0, 0, 0.7) !important;
 
     /* transition from transparent to solid */
     box-shadow: none;

--- a/communitheme/gnome-shell-sass/_dock.scss
+++ b/communitheme/gnome-shell-sass/_dock.scss
@@ -145,7 +145,7 @@
   &.shrink #dash,
   &.dashtodock #dash {
     border: none !important;
-    box-shadow: inset 0 2px 2px -2px black !important;
+    box-shadow: inset 0 2px 2px -2px rgba(0, 0, 0, 0.8) !important;
   }
 
   &.shrink.left #dash,

--- a/communitheme/gnome-shell-sass/_dock.scss
+++ b/communitheme/gnome-shell-sass/_dock.scss
@@ -141,17 +141,16 @@
 /* Communitheme Dock styling */
 
 #dashtodockContainer {
-  // without border: none, there is a 1px gap between windows and the dock
+  // without "border: none", there is a 1px gap between windows and the dock
   &.shrink #dash,
   &.dashtodock #dash {
-    //box-shadow: inset 0 1px $inkstone !important;
     border: none !important;
+    box-shadow: inset 0 2px 2px -2px black !important;
   }
 
   &.shrink.left #dash,
   &.dashtodock.left #dash {
     border: none !important;
-    border-top: 1px solid #2B2929 !important;
   }
 
   &.shrink.right #dash,

--- a/communitheme/gnome-shell-sass/_dock.scss
+++ b/communitheme/gnome-shell-sass/_dock.scss
@@ -145,6 +145,7 @@
   &.shrink #dash,
   &.dashtodock #dash {
     border: none !important;
+    box-shadow: inset 0 1px 2px -1px rgba(0, 0, 0, 0.4) !important;
   }
 
   &.shrink.left #dash,

--- a/communitheme/gnome-shell-sass/_dock.scss
+++ b/communitheme/gnome-shell-sass/_dock.scss
@@ -145,7 +145,6 @@
   &.shrink #dash,
   &.dashtodock #dash {
     border: none !important;
-    box-shadow: inset 0 2px 2px -2px rgba(0, 0, 0, 0.8) !important;
   }
 
   &.shrink.left #dash,

--- a/communitheme/gnome-shell-sass/_dock.scss
+++ b/communitheme/gnome-shell-sass/_dock.scss
@@ -87,7 +87,7 @@
   }
 
   &.running-dots .app-well-app.focused .overview-icon {
-    background-color: rgba(238, 238, 236, 0.1);
+    background-color: rgba(238, 238, 236, 0.2);
   }
 
   &.dashtodock {

--- a/communitheme/gnome-shell-sass/_dock.scss
+++ b/communitheme/gnome-shell-sass/_dock.scss
@@ -151,6 +151,7 @@
   &.shrink.left #dash,
   &.dashtodock.left #dash {
     border: none !important;
+    border-top: 1px solid #2B2929 !important;
   }
 
   &.shrink.right #dash,
@@ -178,6 +179,7 @@
   &.shrink.right #dash,
   &.dashtodock.right #dash {
     // don't let the first icon be too close to the shadow + panel
+    background: #2B2929;
     padding-top: 2px;
   }
 


### PR DESCRIPTION
- removed text and icon shadows
- unified transparency and color of dock and top panel
- added top border color (#2B2929) to dock to draw a separation from top
  panel
- on unmaximized windows: transparencies at 60%
- on maximized windows: transparencies at 40%

(This PR should produce a snap package to be tested before merge to master)