### PR TITLE
Remove orange border for alt-tab

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -665,7 +665,9 @@ StScrollBar {
   }
 
   .switcher-list .item-box:selected {
-    background-color: $selected_bg_color;
+    background-color: $base_hover_color;
+    border: 2px solid $selected_bg_color;
+    border-radius: $small_radius;
     color: $selected_fg_color;
   }
 
@@ -1541,13 +1543,14 @@ StScrollBar {
     visible-width: 32px; //amount visible before hover
     spacing: 11px;
     padding: 8px;
-    border-radius: 9px 0 0 9px;
+    border-radius: $medium_radius 0 0 $medium_radius;
     //border-width: 1px 0 1px 1px; //fixme: can't have non unoform borders :(
-    &:rtl { border-radius: 0 9px 9px 0;}
+    &:rtl { border-radius: 0 $medium_radius $medium_radius 0;}
   }
   .workspace-thumbnail-indicator {
-    border: 4px solid $selected_bg_color;
-    padding: 1px;
+    border: 0px solid $selected_bg_color;
+    border-left-width: 2px;
+    padding: 4px;
   }
 
   //Some hacks I don't even

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -666,7 +666,6 @@ StScrollBar {
 
   .switcher-list .item-box:selected {
     background-color: $base_hover_color;
-    border: 2px solid $selected_bg_color;
     border-radius: $small_radius;
     color: $selected_fg_color;
   }


### PR DESCRIPTION
A small tweak for PR115 to remove the orange border