### PR TITLE
Darken_calendar_seperation_line

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1032,9 +1032,7 @@ StScrollBar {
       }
       .calendar-today {
         font-weight: bold;
-        //color: lighten($fg_color,10%);
-        //background-color: darken($bg_color,5%);
-        border: 1px solid $osd_borders_color; // transparentize($borders_color,0.5);
+        background-color: lighten($bg_color,20%);
       }
       .calendar-day-with-events {
         color: lighten($fg_color,10%);

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -912,7 +912,7 @@ StScrollBar {
     .datemenu-displays-box { spacing: 1em; }
 
     .datemenu-calendar-column {
-      border: 0 solid lighten($bg_color,10%);
+      border: 0 solid lighten($bg_color,7%);
       &:ltr { border-left-width: 1px; }
       &:rtl { border-right-width: 1px; }
     }

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1032,7 +1032,8 @@ StScrollBar {
       }
       .calendar-today {
         font-weight: bold;
-        background-color: lighten($bg_color,20%);
+        background-color: lighten($bg_color,13%);
+        //border: 1px solid lighten($bg_color,17%);
       }
       .calendar-day-with-events {
         color: lighten($fg_color,10%);

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1011,6 +1011,7 @@ StScrollBar {
         border-radius: $small_radius;
         border: 2px solid $selected_bg_color;
         margin: 0;
+        &:hover {background-color: $base_hover_color;}
       }
 
       &.calendar-day-heading {  //day of week heading
@@ -1033,7 +1034,7 @@ StScrollBar {
       .calendar-today {
         font-weight: bold;
         background-color: lighten($bg_color,13%);
-        //border: 1px solid lighten($bg_color,17%);
+        //&:hover{background: $base_hover_color;}
       }
       .calendar-day-with-events {
         color: lighten($fg_color,10%);


### PR DESCRIPTION
Reducing the calendar seperation line brightness - designer approved: https://github.com/ubuntu/gnome-shell-communitheme/issues/93#issuecomment-384639990