### PR TITLE
Notification button active border bleed fix +  transparency

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1608,11 +1608,15 @@ StScrollBar {
     box-shadow: 0 3px 9px 1px transparentize(black, 0.5);
     color: $jet;
 
-    &, &:hover, &:focus, &:active {
+    &, &:focus, &:active {
       & { background-color: white; }
       .message-title { color: $jet; }
       .message-content { color: $inkstone; }
     }
+    &:hover {
+      background: transparentize(white,0.15);
+    }
+
 
     .notification-icon {
       padding: 5px;
@@ -1641,9 +1645,16 @@ StScrollBar {
       color: $inkstone;
       font-weight: 500;
 
-      &:first-child { border-radius: 0 0 0 2px; }
+      &:first-child {
+        border-radius: 0 0 0 2px;
 
-      &:last-child { border-radius: 0 0 2px 0; }
+
+      }
+
+      &:last-child {
+        border-radius: 0 0 2px 0;
+
+      }
 
       &:hover &:focus {
         background-color: rgba(0, 0, 0, 0.12);
@@ -1653,8 +1664,13 @@ StScrollBar {
       &:active {
         background-color: rgba(0, 0, 0, 0.26);
         color: rgba(0, 0, 0, 0.87);
+        border-radius: 0 0 $medium_radius $medium-radius;
       }
     }
+  }
+  .notification-banner .notification-button:active {
+    background-color: rgba(0, 0, 0, 0.26);
+    color: rgba(0, 0, 0, 0.87);
   }
 
   .summary-source-counter {

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1633,10 +1633,7 @@ StScrollBar {
   .notification-button {
     @include button(normal);
     &:active { @include button(active); background-color: rgba(0, 0, 0, 0.26);}
-    //&:focus { @include button(focus); background-color: rgba(0, 0, 0, 0.26);}
     &:hover { @include button(hover); background-color: rgba(0, 0, 0, 0.10);}
-    //&:focus:hover { @include button(focus-hover); background-color: rgba(0, 0, 0, 0.26);}
-    //&:insensitive { @include button(insensitive); }
 
     &:first-child {
       border-radius: 0px 0px 0px $medium_radius; border: none;

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1616,7 +1616,6 @@ StScrollBar {
       background: transparentize(white,0.10);
     }
 
-
     .notification-icon {
       padding: 5px;
     }
@@ -1634,10 +1633,10 @@ StScrollBar {
       padding-top: 0;
       border-top: 1px solid rgba(0, 0, 0, 0.12);
       spacing: 1px;
+
       &:active {
         background-color: rgba(0, 0, 0, 0.26);
         color: rgba(0, 0, 0, 0.87);
-        border-radius: 0 0 $medium_radius $medium-radius;
       }
     }
 
@@ -1648,26 +1647,17 @@ StScrollBar {
       color: $inkstone;
       font-weight: 500;
 
-      &:first-child {
-        border-radius: 0 0 0 $medium-radius;
-      }
-
-      &:last-child {
-        border-radius: 0 0 $medium-radius 0;
-
-      }
-
-      &:hover &:focus {
-        background-color: rgba(0, 0, 0, 0.12);
-        color: rgba(0, 0, 0, 0.87);
+      &:hover{
+        background-color: transparentize(white,0.05);
+        border-radius: 0 0 $medium_radius $medium-radius;};
       }
 
 
-    }
   }
   .notification-banner .notification-button:active {
     background-color: rgba(0, 0, 0, 0.26);
     color: rgba(0, 0, 0, 0.87);
+    border-radius: 0 0 $medium_radius $medium-radius
   }
 
   .summary-source-counter {

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1606,7 +1606,6 @@ StScrollBar {
     border-radius: $medium-radius;
     border: none;
     box-shadow: 0 3px 9px 1px transparentize(black, 0.5);
-    color: $jet;
 
     &, &:focus, &:active {
       & { background-color: white; }
@@ -1614,7 +1613,7 @@ StScrollBar {
       .message-content { color: $inkstone; }
     }
     &:hover {
-      background: transparentize(white,0.15);
+      background: transparentize(white,0.10);
     }
 
 
@@ -1632,7 +1631,6 @@ StScrollBar {
     }
 
     .notification-actions {
-      background-color: transparent;
       padding-top: 0;
       border-top: 1px solid rgba(0, 0, 0, 0.12);
       spacing: 1px;
@@ -1646,13 +1644,11 @@ StScrollBar {
       font-weight: 500;
 
       &:first-child {
-        border-radius: 0 0 0 2px;
-
-
+        border-radius: 0 0 0 $medium-radius;
       }
 
       &:last-child {
-        border-radius: 0 0 2px 0;
+        border-radius: 0 0 $medium-radius 0;
 
       }
 
@@ -1711,53 +1707,53 @@ StScrollBar {
   }
 
     //hotplug
-    .hotplug-transient-box {
+  .hotplug-transient-box {
       padding: 2px 72px 2px 12px;
       spacing: 6px;
-    }
-    .hotplug-notification-item {
-      padding: 2px 10px;
-      color: $inkstone;
+  }
+  .hotplug-notification-item {
+    padding: 2px 10px;
+    color: $inkstone;
 
-      @include button(undecorated);
-      border-radius: 0 0 $small_radius $small_radius;
-      &:focus { padding: 1px 71px 1px 11px; }
-      &:hover { background-color: $silk;}
-      &:active { background-color: transparent; }
-    }
+    @include button(undecorated);
+    border-radius: 0 0 $small_radius $small_radius;
+    &:focus { padding: 1px 71px 1px 11px; }
+    &:hover { background-color: $silk;}
+    &:active { background-color: transparent; }
+  }
 
-    .hotplug-notification-item-icon {
-      icon-size: 24px;
-      padding: 2px 5px;
-    }
+  .hotplug-notification-item-icon {
+    icon-size: 24px;
+    padding: 2px 5px;
+  }
 
-    .hotplug-resident-box { spacing: 8px;}
+  .hotplug-resident-box { spacing: 8px;}
 
-    .hotplug-resident-mount {
-      spacing: 8px;
-      border-radius: 4px;
-      &:hover { background-color: transparent; }
-    }
+  .hotplug-resident-mount {
+    spacing: 8px;
+    border-radius: 4px;
+    &:hover { background-color: transparent; }
+  }
 
-    .hotplug-resident-mount-label {
-      color: inherit;
-      padding-left: 6px;
-    }
+  .hotplug-resident-mount-label {
+    color: inherit;
+    padding-left: 6px;
+  }
 
-    .hotplug-resident-mount-icon {
-      icon-size: 24px;
-      padding-left: 6px;
-    }
+  .hotplug-resident-mount-icon {
+    icon-size: 24px;
+    padding-left: 6px;
+  }
 
-    .hotplug-resident-eject-icon {
-      icon-size: 16px;
-    }
+  .hotplug-resident-eject-icon {
+    icon-size: 16px;
+  }
 
-    .hotplug-resident-eject-button {
-      padding: 7px;
-      border-radius: 5px;
-      color: $inkstone;
-    }
+  .hotplug-resident-eject-button {
+    padding: 7px;
+    border-radius: 5px;
+    color: $inkstone;
+  }
 
 /* Eeeky things */
 

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1615,7 +1615,7 @@ StScrollBar {
     &:hover { background: white; }
   }
 
-  .notification-icon { padding: 5px; }
+  .notification-icon { padding: 5px; -gtk-icon-shadow: none;}
 
   .notification-content {
     padding: 5px;
@@ -1627,8 +1627,7 @@ StScrollBar {
   .notification-actions {
     padding-top: 0;
     border-top: 1px solid rgba(0, 0, 0, 0.12);
-    spacing: 1px;
-    &:active { background-color: rgba(0, 0, 0, 0.26);}
+    spacing: 0px;
   }
 
   .notification-button {
@@ -1637,10 +1636,13 @@ StScrollBar {
     background-color: transparent;
     color: $inkstone;
     font-weight: 500;
-    &:active { background-color: rgba(0, 0, 0, 0.26); border-radius: 0 0 $medium-radius $medium-radius;}
-    //&:first-child:active{ border-radius: 0 0 0 $medium-radius; }
-    //&:last-child:active{ border-radius: 0 0 $medium-radius 0 ;}
+    &:active { background-color: rgba(0, 0, 0, 0.26); }
+    
   }
+  .notification-button {
+    &:first-child { &, &:active { border-radius: 0 0 0 $medium-radius; } }
+    &:last-child { &, &:active { border-radius: 0 0 $medium-radius 0; } }
+}
 
   .summary-source-counter {
     font-size: 10pt;

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1608,56 +1608,38 @@ StScrollBar {
     box-shadow: 0 3px 9px 1px transparentize(black, 0.5);
 
     &, &:focus, &:active {
-      & { background-color: white; }
+      & { background-color: transparentize(white,0.10); }
       .message-title { color: $jet; }
       .message-content { color: $inkstone; }
     }
-    &:hover {
-      background: transparentize(white,0.10);
-    }
-
-    .notification-icon {
-      padding: 5px;
-    }
-
-    .notification-content {
-      padding: 5px;
-      spacing: 5px;
-    }
-
-    .secondary-icon {
-      icon-size: 1.14286em;
-    }
-
-    .notification-actions {
-      padding-top: 0;
-      border-top: 1px solid rgba(0, 0, 0, 0.12);
-      spacing: 1px;
-
-      &:active {
-        background-color: rgba(0, 0, 0, 0.26);
-        color: rgba(0, 0, 0, 0.87);
-      }
-    }
-
-    .notification-button {
-      min-height: 35px;
-      padding: 0 16px;
-      background-color: transparent;
-      color: $inkstone;
-      font-weight: 500;
-
-      &:hover{
-        background-color: transparentize(white,0.05);
-        border-radius: 0 0 $medium_radius $medium-radius;};
-      }
-
-
+    &:hover { background: white; }
   }
-  .notification-banner .notification-button:active {
-    background-color: rgba(0, 0, 0, 0.26);
-    color: rgba(0, 0, 0, 0.87);
-    border-radius: 0 0 $medium_radius $medium-radius
+
+  .notification-icon { padding: 5px; }
+
+  .notification-content {
+    padding: 5px;
+    spacing: 5px;
+  }
+
+  .secondary-icon { icon-size: 1.14286em; }
+
+  .notification-actions {
+    padding-top: 0;
+    border-top: 1px solid rgba(0, 0, 0, 0.12);
+    spacing: 1px;
+    &:active { background-color: rgba(0, 0, 0, 0.26);}
+  }
+
+  .notification-button {
+    min-height: 35px;
+    padding: 0 16px;
+    background-color: transparent;
+    color: $inkstone;
+    font-weight: 500;
+    &:active { background-color: rgba(0, 0, 0, 0.26); border-radius: 0 0 $medium-radius $medium-radius;}
+    //&:first-child:active{ border-radius: 0 0 0 $medium-radius; }
+    //&:last-child:active{ border-radius: 0 0 $medium-radius 0 ;}
   }
 
   .summary-source-counter {

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1634,6 +1634,11 @@ StScrollBar {
       padding-top: 0;
       border-top: 1px solid rgba(0, 0, 0, 0.12);
       spacing: 1px;
+      &:active {
+        background-color: rgba(0, 0, 0, 0.26);
+        color: rgba(0, 0, 0, 0.87);
+        border-radius: 0 0 $medium_radius $medium-radius;
+      }
     }
 
     .notification-button {
@@ -1657,11 +1662,7 @@ StScrollBar {
         color: rgba(0, 0, 0, 0.87);
       }
 
-      &:active {
-        background-color: rgba(0, 0, 0, 0.26);
-        color: rgba(0, 0, 0, 0.87);
-        border-radius: 0 0 $medium_radius $medium-radius;
-      }
+
     }
   }
   .notification-banner .notification-button:active {

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1716,10 +1716,10 @@ StScrollBar {
     color: $inkstone;
 
     @include button(undecorated);
-    border-radius: 0 0 $small_radius $small_radius;
+    border-radius: 0 0 $medium_radius $medium_radius;
     &:focus { padding: 1px 71px 1px 11px; }
     &:hover { background-color: $silk;}
-    &:active { background-color: transparent; }
+    &:active { background-color: rgba(0, 0, 0, 0.26); border: none;}
   }
 
   .hotplug-notification-item-icon {

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1631,18 +1631,32 @@ StScrollBar {
   }
 
   .notification-button {
+    @include button(normal);
+    &:active { @include button(active); background-color: rgba(0, 0, 0, 0.26);}
+    //&:focus { @include button(focus); background-color: rgba(0, 0, 0, 0.26);}
+    &:hover { @include button(hover); background-color: rgba(0, 0, 0, 0.10);}
+    //&:focus:hover { @include button(focus-hover); background-color: rgba(0, 0, 0, 0.26);}
+    //&:insensitive { @include button(insensitive); }
+
+    &:first-child {
+      border-radius: 0px 0px 0px $medium_radius; border: none;
+    }
+    &:last-child {
+      border-right-width: 0px;
+      border-radius: 0px 0px $medium_radius 0px; border: none;
+    }
+    &:first-child:last-child {
+      border-right-width: 0px;
+      border-radius: 0px 0px $medium_radius $medium_radius;border: none;
+    }
     min-height: 35px;
     padding: 0 16px;
     background-color: transparent;
     color: $inkstone;
     font-weight: 500;
-    &:active { background-color: rgba(0, 0, 0, 0.26); }
-    
+    &:selected { border: none;}
+    border: none;
   }
-  .notification-button {
-    &:first-child { &, &:active { border-radius: 0 0 0 $medium-radius; } }
-    &:last-child { &, &:active { border-radius: 0 0 $medium-radius 0; } }
-}
 
   .summary-source-counter {
     font-size: 10pt;


### PR DESCRIPTION
![screenshot from 2018-04-26 22-46-39](https://user-images.githubusercontent.com/15329494/39331332-8e6f4cba-49a4-11e8-97bf-388f6eef11d8.png)
![screenshot from 2018-04-26 22-46-26](https://user-images.githubusercontent.com/15329494/39331333-8e85d386-49a4-11e8-977f-fbb3cf25ce28.png)
![peek 2018-04-26 22-35](https://user-images.githubusercontent.com/15329494/39331344-961dca04-49a4-11e8-81b1-98e51b970bea.gif)
@godlyranchdressing could you help me with one more thing: the symbolic notification icons have a very light color and I can't find the property to change it :grin: 
![image](https://user-images.githubusercontent.com/15329494/39331843-ee900ade-49a5-11e8-8773-c77bdc16aedc.png)
