### PR TITLE
fix_wrong_shadow_on_clone_border

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1295,13 +1295,13 @@ StScrollBar {
   }
 
   .window-clone-border {
-    $_bg: transparentize(white,0.65);
+    $_bg: transparentize(white,0.75);
     border: 5px solid $_bg;
     border-radius: $medium_radius;
     // For window decorations with round corners we can't match
     // the exact shape when the window is scaled. So apply a shadow
     // to fix that case
-    box-shadow: inset 0px 0px 5px 0px $_bg;
+    box-shadow: inset 0 0 0 1px $_bg;
   }
   .window-caption {
     spacing: 25px;


### PR DESCRIPTION
Just a wrong shadow fix
Border is sharp now, was dizzy before. This is how it will look then:
![screenshot from 2018-05-01 18-11-11](https://user-images.githubusercontent.com/15329494/39481263-1f2c67c8-4d6b-11e8-9633-6bb03056f45c.png)
