### PR TITLE
Light dialog windows part 3

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -727,7 +727,9 @@ StScrollBar {
 .workspace-switcher-group { padding: 12px; }
 
   .workspace-switcher-container {
-    @extend %osd-panel;
+    @extend %dialog_window;
+    padding: 5px;
+    border-radius: $medium_radius;
   }
 
   .workspace-switcher {
@@ -740,7 +742,8 @@ StScrollBar {
 
   .ws-switcher-active-up, .ws-switcher-active-down {
     height: 50px;
-    background-color: $selected_bg_color;
+    background-color: rgba(0, 0, 0, 0.36);
+;
     color: $selected_fg_color;
     //background-image: url("resource:///org/gnome/shell/theme/ws-switch-arrow-up.png");
     background-size: 32px;
@@ -748,7 +751,7 @@ StScrollBar {
   }
 
   .ws-switcher-active-up { background-image: url("ws-switch-arrow-up.svg"); }
-  .ws-switcher-active-down { background-image: url("ws-switch-arrow-down.svg"); }
+  .ws-switcher-active-down {background-image: url("ws-switch-arrow-down.svg"); }
 
   .ws-switcher-box {
     height: 50px;

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -686,9 +686,10 @@ StScrollBar {
   }
 
   .switcher-list .item-box:selected {
-    background-color: rgba(0, 0, 0, 0.26);
+    background-color: rgba(0, 0, 0, 0.36);
     border-radius: $small_radius;
     color: white;
+    font-weight: 500;
   }
 
   .switcher-list .thumbnail-box {


### PR DESCRIPTION
![peek 2018-05-05 02-10](https://user-images.githubusercontent.com/15329494/39657582-7cc1ef16-5009-11e8-9fb0-962d88354d60.gif)

- increased alt tab switcher selected app contrast
- adapted workspace switcher (ctrl+alt+arrow up/down) to the new light style