### PR TITLE
Alter window switcher borders

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1335,7 +1335,7 @@ StScrollBar {
   }
 
   .window-clone-border {
-    $_bg: transparentize(white,0.4);
+    $_bg: transparentize(white,0.5);
     border: 5px solid $_bg;
     border-radius: $medium_radius;
     // For window decorations with round corners we can't match

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -689,7 +689,7 @@ StScrollBar {
   .switcher-list .item-box:selected {
     //background-color: $light_base_active_color;
     background-color: $base_active_color;
-    border: 2px solid transparentize(white,0.5);
+    border: 1px solid $osd_borders_color;
     border-radius: $small_radius;
     //color: $dark_fg_color;
     color: $fg_color;

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -689,6 +689,7 @@ StScrollBar {
   .switcher-list .item-box:selected {
     //background-color: $light_base_active_color;
     background-color: $base_active_color;
+    border: 2px solid transparentize(white,0.5);
     border-radius: $small_radius;
     //color: $dark_fg_color;
     color: $fg_color;
@@ -1334,7 +1335,7 @@ StScrollBar {
   }
 
   .window-clone-border {
-    $_bg: transparentize(white,0.75);
+    $_bg: transparentize(white,0.4);
     border: 5px solid $_bg;
     border-radius: $medium_radius;
     // For window decorations with round corners we can't match


### PR DESCRIPTION
- Adds a semi-transparent white border to alt-tab
- Makes the white border more opaque for overview window selection

![switcher](https://user-images.githubusercontent.com/27529229/40381850-cba64842-5dca-11e8-99dd-934520349397.png)
![atl-tab](https://user-images.githubusercontent.com/27529229/40381851-cbd93e50-5dca-11e8-93e4-7f13ec619200.png)
