### PR TITLE
Mockup of solid color for panel and dock

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -808,7 +808,7 @@ StScrollBar {
 
 #panel {
   $_fg: darken($panel_fg_color, 5%);
-  background-color: transparentize($panel_bg_color, $panel-alpha-value);
+  background-color: transparentize($panel-solid-bg, $panel-alpha-value);
 
   /* transition from solid to transparent */
   transition-duration: 500ms;
@@ -908,7 +908,7 @@ StScrollBar {
   .screencast-indicator { color: $warning_color; }
 
   &.solid {
-    background-color: transparentize($panel_bg_color, $panel_opaque_value);
+    background-color: transparentize($panel-solid-bg, $panel_opaque_value);
 
     /* transition from transparent to solid */
     box-shadow: none;

--- a/communitheme/gnome-shell-sass/_dock.scss
+++ b/communitheme/gnome-shell-sass/_dock.scss
@@ -180,7 +180,7 @@
   &.shrink.right #dash,
   &.dashtodock.right #dash {
     // don't let the first icon be too close to the shadow + panel
-    background: #2B2929;
+    background-color: $panel-solid-bg;
     padding-top: 2px;
   }
 

--- a/communitheme/gnome-shell-sass/_ubuntu-colors.scss
+++ b/communitheme/gnome-shell-sass/_ubuntu-colors.scss
@@ -17,3 +17,5 @@ $yellow: #F89B0F;
 $green: #3EB34F;
 $blue: #19B6EE;
 $purple: #762572;
+
+$panel-solid-bg: #35282f; // mix($orange, black, 16%);


### PR DESCRIPTION
This is a testing PR, to let user testing this change with snap, do not merge.

I took (one of) the main colors obtained with default Bionic wallpaper
and old panel transparency (0.12) and use it as solid color for both
panel and dock.

Color is #35282F