### PR TITLE
jet_shell

### DIFF
--- a/communitheme/gnome-shell-sass/_colors.scss
+++ b/communitheme/gnome-shell-sass/_colors.scss
@@ -36,8 +36,8 @@ $indication_bg_color: #19B6EE;
 $osd_fg_color: $fg_color;
 $osd_bg_color: $jet;//#2B2929;
 $button_bg_color: $osd_bg_color;
-$osd_borders_color: transparentize(white, 0.85);
-$osd_separator_color: lighten($osd_bg_color,8%);
+$osd_borders_color: transparentize($porcelain, 0.90);
+$osd_separator_color: lighten($osd_bg_color,4%);
 //
 $base_hover_color: transparentize($fg_color, 0.85);
 $base_active_color: transparentize($fg_color, 0.80);

--- a/communitheme/gnome-shell-sass/_colors.scss
+++ b/communitheme/gnome-shell-sass/_colors.scss
@@ -9,9 +9,9 @@ $caption_fg_color: darken($fg_color, 20%);
 $text_color: darken($fg_color, 30%);
 $inactive_element_color: darken($fg_color, 40%);
 //
-$panel_bg_color: $jet;//#2B2929;
+$panel_bg_color: lighten($jet, 4%);
 $panel_fg_color: $porcelain;
-$dash_bg_color: $jet;//#3B3939;
+$dash_bg_color: $panel_bg_color;
 $menu_color: #252525;
 //
 $selected_fg_color: #ffffff;
@@ -34,7 +34,7 @@ $neutral_color: $blue;
 $indication_bg_color: #19B6EE;
 //
 $osd_fg_color: $fg_color;
-$osd_bg_color: $jet;//#2B2929;
+$osd_bg_color: $panel_bg_color;
 $button_bg_color: $osd_bg_color;
 $osd_borders_color: transparentize($porcelain, 0.90);
 $osd_separator_color: lighten($osd_bg_color,4%);

--- a/communitheme/gnome-shell-sass/_colors.scss
+++ b/communitheme/gnome-shell-sass/_colors.scss
@@ -9,7 +9,7 @@ $caption_fg_color: darken($fg_color, 20%);
 $text_color: darken($fg_color, 30%);
 $inactive_element_color: darken($fg_color, 40%);
 //
-$panel_bg_color: lighten($jet, 4%);
+$panel_bg_color: lighten($jet, 2%);
 $panel_fg_color: $porcelain;
 $dash_bg_color: $panel_bg_color;
 $menu_color: #252525;

--- a/communitheme/gnome-shell-sass/_colors.scss
+++ b/communitheme/gnome-shell-sass/_colors.scss
@@ -9,9 +9,9 @@ $caption_fg_color: darken($fg_color, 20%);
 $text_color: darken($fg_color, 30%);
 $inactive_element_color: darken($fg_color, 40%);
 //
-$panel_bg_color: #2B2929;
+$panel_bg_color: $jet;//#2B2929;
 $panel_fg_color: $porcelain;
-$dash_bg_color: #3B3939;
+$dash_bg_color: $jet;//#3B3939;
 $menu_color: #252525;
 //
 $selected_fg_color: #ffffff;
@@ -34,10 +34,10 @@ $neutral_color: $blue;
 $indication_bg_color: #19B6EE;
 //
 $osd_fg_color: $fg_color;
-$osd_bg_color: #2B2929;
+$osd_bg_color: $jet;//#2B2929;
 $button_bg_color: $osd_bg_color;
 $osd_borders_color: transparentize(white, 0.85);
-$osd_separator_color: lighten($bg_color,8%);
+$osd_separator_color: lighten($osd_bg_color,8%);
 //
 $base_hover_color: transparentize($fg_color, 0.85);
 $base_active_color: transparentize($fg_color, 0.80);

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -11,7 +11,7 @@ $panel_opaque_value: 0.0;
 $dash-alpha-value: 0.6;
 $dash-opaque-alpha-value: $panel_opaque_value;
 
-$popover-alpha-value: 0.015;
+$popover-alpha-value: 0.025;
 
 $small_radius: 4px;
 $medium_radius: 6px;

--- a/communitheme/gnome-shell-sass/_dock.scss
+++ b/communitheme/gnome-shell-sass/_dock.scss
@@ -180,7 +180,7 @@
   &.shrink.right #dash,
   &.dashtodock.right #dash {
     // don't let the first icon be too close to the shadow + panel
-    background: $dash_bg_color;//#2B2929;
+    background: $dash_bg_color;
     padding-top: 2px;
   }
 

--- a/communitheme/gnome-shell-sass/_dock.scss
+++ b/communitheme/gnome-shell-sass/_dock.scss
@@ -180,7 +180,7 @@
   &.shrink.right #dash,
   &.dashtodock.right #dash {
     // don't let the first icon be too close to the shadow + panel
-    background: #2B2929;
+    background: $dash_bg_color;//#2B2929;
     padding-top: 2px;
   }
 


### PR DESCRIPTION
So this has been proposed by jaggers and Aaron on the hub and could work.

Some additional changes form my side:
- reverted the brightening of the OSD/popup border since the contrast to the grey gtk headers is more than enough with a jet shell
- increased the transparency of popups by 0.1 since this still works pretty good with jet

![jet_02](https://user-images.githubusercontent.com/15329494/40490560-20aca794-5f6c-11e8-905d-00db3e4c4cf6.png)
![jet_01](https://user-images.githubusercontent.com/15329494/40490561-20c6aa22-5f6c-11e8-92cf-319c623e5fe6.png)
![screenshot from 2018-05-24 15-59-59](https://user-images.githubusercontent.com/15329494/40490574-2d1d6518-5f6c-11e8-8d68-75bb738aca9d.png)
![screenshot from 2018-05-24 15-59-55](https://user-images.githubusercontent.com/15329494/40490575-2d3d904a-5f6c-11e8-8fab-67fb22d64ae6.png)


@madsrh @luxamman @clobrano @godlyranchdressing  now we can test (snap) and choose between this PRs or https://github.com/ubuntu/gnome-shell-communitheme/pull/188
Or just reject both! :dancer: 