### PR TITLE
Popover separators + transparency bump

### DIFF
--- a/communitheme/gnome-shell-sass/_colors.scss
+++ b/communitheme/gnome-shell-sass/_colors.scss
@@ -36,8 +36,7 @@ $indication_bg_color: #19B6EE;
 $osd_fg_color: $fg_color;
 $osd_bg_color: $panel_bg_color;
 $button_bg_color: $osd_bg_color;
-$osd_borders_color: transparentize($porcelain, 0.90);
-$osd_separator_color: lighten($osd_bg_color,4%);
+$osd_borders_color: transparentize($fg_color, 0.90);
 //
 $base_hover_color: transparentize($fg_color, 0.85);
 $base_active_color: transparentize($fg_color, 0.80);

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -11,7 +11,7 @@ $panel_opaque_value: 0.0;
 $dash-alpha-value: 0.6;
 $dash-opaque-alpha-value: $panel_opaque_value;
 
-$popover-alpha-value: 0.025;
+$popover-alpha-value: 0.035;
 
 $small_radius: 4px;
 $medium_radius: 6px;
@@ -601,7 +601,7 @@ StScrollBar {
     height: 1px; //not really the whole box
     margin: 6px 64px;
     background-color: transparent;
-    border-color: $osd_separator_color;
+    border-color: $osd_borders_color;
     border-bottom-width: 1px;
     border-bottom-style: solid;
   }
@@ -956,7 +956,7 @@ StScrollBar {
     .datemenu-displays-box { spacing: 1em; }
 
     .datemenu-calendar-column {
-      border: 0 solid $osd_separator_color;
+      border: 0 solid $osd_borders_color;
       &:ltr { border-left-width: 1px; }
       &:rtl { border-right-width: 1px; }
     }


### PR DESCRIPTION
- The extra darkness of the popover will make a slightly higher transparency still usable and also lessen the contrast of the dark popovers
- have $osd_borders_color use $fg_color instead of $porcelain (to make it work across in the light theme if we ever get to working on that)
- replace $osd_separator_color with $osd_borders_color