### PR TITLE
Solid Notifications

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1656,7 +1656,7 @@ StScrollBar {
     box-shadow: 0 3px 9px 1px transparentize(black, 0.5);
 
     &, &:focus, &:active {
-      & { background-color: transparentize($light_base_color,0.10); }
+      & { background-color: $light_base_color }
       .message-title { color: darken($dark_fg_color, 10%); }
       .message-content { color: $dark_fg_color;
        }


### PR DESCRIPTION
![peek 2018-06-13 11-32](https://user-images.githubusercontent.com/15329494/41342955-b3bd3760-6efd-11e8-9ca3-c2fc32cc13c7.gif)

- solid notifications
- solid banner on hover
- light_base_hover_color only for notification buttons
- fixes a bug where gtk headers receive an enlightenment when hovering above the transparent notifications

That's a request from designer @madsrh 