### PR TITLE
lighter insensitive entries border color for light dialogues only

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -782,7 +782,10 @@ StScrollBar {
     $_fg: $dark_fg_color;
     @include entry(normal, $tc: $_fg, $c: $_bg);
     &:focus { @include entry(focus, $tc: $_fg, $c: $_bg);}
-    &:insensitive { @include entry(insensitive, $tc: $_fg, $c: $_bg);}
+    &:insensitive {
+      @include entry(insensitive, $tc: $_fg, $c: $_bg);
+      border-color: $silk;
+    }
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/ubuntu/gnome-shell-communitheme/issues/215

![screenshot from 2018-06-14 23-10-47](https://user-images.githubusercontent.com/15329494/41438676-6325d858-7028-11e8-83e3-e3a1d9017006.png)

@madsrh 