### PR TITLE
Don't use symbolic icons for appmenu

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -854,7 +854,6 @@ StScrollBar {
     transition-duration: 100ms;
 
     .app-menu-icon {
-      -st-icon-style: symbolic;
       margin-left: 4px;
       margin-right: 4px;
       //dimensions of the icon are hardcoded


### PR DESCRIPTION
Not all icons are symbolics, also, the symbol set doesn't match the
colored one in the Dock.
Be consistent by always using the colored icon thus.