### PR TITLE
Medium radius for alt tab switcher selected app & 0.1 less transparency for .window-clone-border

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -689,7 +689,7 @@ StScrollBar {
   .switcher-list .item-box:selected {
     //background-color: $light_base_active_color;
     background-color: $base_active_color;
-    border-radius: $small_radius;
+    border-radius: $medium_radius;
     //color: $dark_fg_color;
     color: $fg_color;
   }

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1329,7 +1329,7 @@ StScrollBar {
   }
 
   .window-clone-border {
-    $_bg: transparentize(white,0.75);
+    $_bg: transparentize(white,0.65);
     border: 5px solid $_bg;
     border-radius: $medium_radius;
     // For window decorations with round corners we can't match


### PR DESCRIPTION
Closes https://github.com/ubuntu/gnome-shell-communitheme/issues/221
&
Some middle ground from this https://github.com/ubuntu/gnome-shell-communitheme/pull/186
and master