### PR TITLE
Flatten insensitive clear all button in the calendar popup

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1109,7 +1109,7 @@ StScrollBar {
         border-color: lighten($bg_color,10%);
         &:hover,&:focus { @include button(hover); }
         &:active { @include button(undecorated-active); color: darken($fg_color,25%);}
-        &:insensitive { @include button(insensitive); }
+        &:insensitive { @include button(undecorated); border-color: transparentize(darken($fg_color,40%),0.8);}
         margin: 1.5em 1.5em 0;
       }
 


### PR DESCRIPTION
Closes https://github.com/ubuntu/gnome-shell-communitheme/issues/207
![peek 2018-06-29 15-01](https://user-images.githubusercontent.com/15329494/42093687-7d8f8852-7bad-11e8-8bbc-d53ef5afb72d.gif)
