### PR TITLE
Popup alpha

### DIFF
--- a/communitheme/gnome-shell-sass/_colors.scss
+++ b/communitheme/gnome-shell-sass/_colors.scss
@@ -38,7 +38,7 @@ $indication_bg_color: #19B6EE;
 $osd_fg_color: $fg_color;
 $osd_bg_color: $panel_bg_color;
 $button_bg_color: $osd_bg_color;
-$osd_borders_color: transparentize($fg_color, 0.90);
+$osd_borders_color: transparentize($fg_color, 0.91);
 //
 $base_hover_color: transparentize($fg_color, 0.85);
 $base_active_color: transparentize($fg_color, 0.80);

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -11,7 +11,7 @@ $panel_opaque_value: 0.0;
 $dash-alpha-value: 0.6;
 $dash-opaque-alpha-value: $panel_opaque_value;
 
-$popover-alpha-value: 0.035;
+$popover-alpha-value: 0.025;
 
 $small_radius: 4px;
 $medium_radius: 6px;


### PR DESCRIPTION
Current master:
![screenshot from 2018-06-28 10-15-25](https://user-images.githubusercontent.com/15329494/42109403-c3d278a8-7bdd-11e8-9920-be3295592914.png)
This PR:
![screenshot from 2018-06-29 20-50-22](https://user-images.githubusercontent.com/15329494/42109485-156c2e2a-7bde-11e8-927b-2dadbb6eabf3.png)


Popup transparency is little bit too high which looks a bit "unprofessional" in a corner case where you have very bright and very dark elements underlying. 

@madsrh @clobrano what's your opinion on that? Please try this PR and compare it to the current master on your machines and share your opinion