### PR TITLE
Remove the border from dialogs and notifications

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -780,6 +780,8 @@ StScrollBar {
   StEntry {
     @extend %light_entry;
   }
+
+  border: none;
 }
 
 /* Tiled window previews */
@@ -1677,6 +1679,8 @@ StScrollBar {
     StEntry {
       @extend %light_entry
     }
+
+    border:none;
   }
 
   .notification-icon { padding: 5px;}


### PR DESCRIPTION
This causes a gap between buttons and the underlying background. 

After removing the border the press effect of buttons does not "end" anymore before the edge:
![screenshot from 2018-07-04 15-48-40](https://user-images.githubusercontent.com/15329494/42280989-91bdbecc-7fa2-11e8-9a2c-fb07ba902043.png)
![screenshot from 2018-07-04 15-57-13](https://user-images.githubusercontent.com/15329494/42281137-f436314c-7fa2-11e8-8628-0c17cde1807e.png)


Current master:
![screenshot from 2018-07-04 15-55-52](https://user-images.githubusercontent.com/15329494/42281057-beea4d2a-7fa2-11e8-9ef8-af163ddc954e.png)
![screenshot from 2018-07-04 15-56-22](https://user-images.githubusercontent.com/15329494/42281089-d25c3abc-7fa2-11e8-94d7-c147c628655b.png)


@madsrh @clobrano  any opinions?