### PR TITLE
Increase contrast of the unfilled progressbar in OSDs by using dark blue

### DIFF
--- a/communitheme/gnome-shell-sass/_colors.scss
+++ b/communitheme/gnome-shell-sass/_colors.scss
@@ -33,7 +33,8 @@ $error_color: $red;
 $success_color: $green;
 $destructive_color: darken($red, 10%);
 $neutral_color: $blue;
-$indication_bg_color: #19B6EE;
+$indication_bg_color: $blue;
+$inactive_indication_bg_color: darken($indication_bg_color,30%);
 //
 $osd_fg_color: $fg_color;
 $osd_bg_color: $panel_bg_color;

--- a/communitheme/gnome-shell-sass/_colors.scss
+++ b/communitheme/gnome-shell-sass/_colors.scss
@@ -34,7 +34,7 @@ $success_color: $green;
 $destructive_color: darken($red, 10%);
 $neutral_color: $blue;
 $indication_bg_color: $blue;
-$inactive_indication_bg_color: $ash;
+$inactive_indication_bg_color: darken($ash,5%);
 //
 $osd_fg_color: $fg_color;
 $osd_bg_color: $panel_bg_color;

--- a/communitheme/gnome-shell-sass/_colors.scss
+++ b/communitheme/gnome-shell-sass/_colors.scss
@@ -34,7 +34,7 @@ $success_color: $green;
 $destructive_color: darken($red, 10%);
 $neutral_color: $blue;
 $indication_bg_color: $blue;
-$inactive_indication_bg_color: mix($indication_bg_color, $jet, 30%);
+$inactive_indication_bg_color: $ash;
 //
 $osd_fg_color: $fg_color;
 $osd_bg_color: $panel_bg_color;

--- a/communitheme/gnome-shell-sass/_colors.scss
+++ b/communitheme/gnome-shell-sass/_colors.scss
@@ -34,7 +34,7 @@ $success_color: $green;
 $destructive_color: darken($red, 10%);
 $neutral_color: $blue;
 $indication_bg_color: $blue;
-$inactive_indication_bg_color: darken($indication_bg_color,30%);
+$inactive_indication_bg_color: mix($indication_bg_color, $jet, 30%);
 //
 $osd_fg_color: $fg_color;
 $osd_bg_color: $panel_bg_color;

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -629,7 +629,7 @@ StScrollBar {
 
   .osd-monitor-label { font-size: 3em; }
   .level {
-    $c: darken($indication_bg_color, 35%);
+    $c: darken($indication_bg_color, 30%);
     height: 0.3em;
     border-radius: 0.3em;
     background-color: $c;

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -146,14 +146,12 @@ StScrollBar {
 /* Slider */
 
 .slider {
-  $_bg: $indication_bg_color;
-  $_inactive_bg: darken($indication_bg_color, 30%);
   height: 1em;
   -slider-height: 0.1em;
-  -slider-background-color: $_inactive_bg; //background of the trough
-  -slider-border-color: $_inactive_bg; //trough border color
-  -slider-active-background-color: $_bg; //active trough fill
-  -slider-active-border-color: $_bg; //active trough border
+  -slider-background-color: $inactive_indication_bg_color; //background of the trough
+  -slider-border-color: $inactive_indication_bg_color; //trough border color
+  -slider-active-background-color: $indication_bg_color; //active trough fill
+  -slider-active-border-color: $indication_bg_color; //active trough border
   -slider-border-width: 1px;
   -slider-handle-radius: 8px;
 }
@@ -629,7 +627,7 @@ StScrollBar {
 
   .osd-monitor-label { font-size: 3em; }
   .level {
-    $c: darken($indication_bg_color, 30%);
+    $c: $inactive_indication_bg_color;
     height: 0.3em;
     border-radius: 0.3em;
     background-color: $c;

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -636,7 +636,7 @@ StScrollBar {
     color: $c;
   }
   .level-bar {
-    background-color: $indication_bg_color; // $osd_fg_color;
+    background-color: $indication_bg_color;
     border-radius: 0.3em;
   }
 }

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -628,7 +628,7 @@ StScrollBar {
 
   .osd-monitor-label { font-size: 3em; }
   .level {
-    $c: darken($dark_fill,15%);
+    $c: darken($blue, 30%);
     height: 0.3em;
     border-radius: 0.3em;
     background-color: $c;

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -147,7 +147,7 @@ StScrollBar {
 
 .slider {
   $_bg: $indication_bg_color;
-  $_inactive_bg: lighten($inactive_indication_bg_color,0%);
+  $_inactive_bg: $inactive_indication_bg_color;
   height: 1em;
   -slider-height: 0.2em; //increase the height because of the border removal
   -slider-background-color:  $_inactive_bg;//background of the trough

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -147,7 +147,7 @@ StScrollBar {
 
 .slider {
   $_bg: $indication_bg_color;
-  $_inactive_bg: lighten($inactive_indication_bg_color,5%);
+  $_inactive_bg: lighten($inactive_indication_bg_color,0%);
   height: 1em;
   -slider-height: 0.2em; //increase the height because of the border removal
   -slider-background-color:  $_inactive_bg;//background of the trough

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -146,11 +146,12 @@ StScrollBar {
 /* Slider */
 
 .slider {
-  $_bg: $indication_bg_color; // $selected_bg_color;
+  $_bg: $indication_bg_color;
+  $_inactive_bg: darken($indication_bg_color, 30%);
   height: 1em;
   -slider-height: 0.1em;
-  -slider-background-color: $dark_fill; // $osd_borders_color; //background of the trough
-  -slider-border-color: $dark_fill; // $osd_borders_color; //trough border color
+  -slider-background-color: $_inactive_bg; //background of the trough
+  -slider-border-color: $_inactive_bg; //trough border color
   -slider-active-background-color: $_bg; //active trough fill
   -slider-active-border-color: $_bg; //active trough border
   -slider-border-width: 1px;
@@ -628,7 +629,7 @@ StScrollBar {
 
   .osd-monitor-label { font-size: 3em; }
   .level {
-    $c: darken($blue, 30%);
+    $c: darken($indication_bg_color, 35%);
     height: 0.3em;
     border-radius: 0.3em;
     background-color: $c;

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -146,14 +146,17 @@ StScrollBar {
 /* Slider */
 
 .slider {
+  $_bg: $indication_bg_color;
+  $_inactive_bg: lighten($inactive_indication_bg_color,5%);
   height: 1em;
-  -slider-height: 0.1em;
-  -slider-background-color: $inactive_indication_bg_color; //background of the trough
-  -slider-border-color: $inactive_indication_bg_color; //trough border color
-  -slider-active-background-color: $indication_bg_color; //active trough fill
-  -slider-active-border-color: $indication_bg_color; //active trough border
-  -slider-border-width: 1px;
+  -slider-height: 0.2em; //increase the height because of the border removal
+  -slider-background-color:  $_inactive_bg;//background of the trough
+  //-slider-border-color: $_inactive_bg; //trough border color but border is 0px
+  -slider-active-background-color: $_bg; //active trough fill
+  -slider-active-border-color: $_bg; //active trough border
+  -slider-border-width: 0px; //remove the border for a more flat trough
   -slider-handle-radius: 8px;
+  color: $fg_color; //Color of the knob/slider-handle
 }
 
 /* Check Boxes */


### PR DESCRIPTION
Closes https://github.com/ubuntu/gnome-shell-communitheme/issues/232

But we discussed a different approach:
![osdsssss](https://user-images.githubusercontent.com/15329494/42314362-22d3e02e-8045-11e8-98ec-5ef0285464ef.gif)

Arguments:
Pro:
- a darker grey could be a mismatch with the dark grey used in the suru icon so we would have blue/dark blue and white/light grey instead of grey, dark grey, blue, darker grey

Con:
- the other progress bars look diferent

Alternative and suggested by mads use a slate:
![peek 2018-07-05 11-21](https://user-images.githubusercontent.com/15329494/42314527-8737bf36-8045-11e8-98ae-813602cca5a9.gif)

Pro:
- it's grey and the other progress bars use a grey too

Con:
- it does not fit the grey in the suru icon and could create the desire to adapt it to the grey in the icon (which does not have a enough contrast to the blue, which is why mads created the issue)

@clobrano  you decide ;D since mads and me like  both
