### PR TITLE
Dark login screen

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -1944,12 +1944,12 @@ StScrollBar {
   border: none;
   background-color: transparent;
 
-  StEntry {
-    @extend %light_entry;
-    &:focus { border-color: transparentize($fg_color,0.1); }
-    &:insensitive {
-      @include entry(insensitive, $tc: $slate, $c: $porcelain);
-      color: lighten($insensitive_fg_color,40%);}
+  > StBoxLayout {
+  // this is the main window that the widgets are drawn on
+    background-color: $_popover_bg_color;
+    padding: 12px 40px 24px 40px;
+    border: 1px solid $osd_borders_color;
+    border-radius: $large_radius;
   }
 
   .modal-dialog-button-box { spacing: 3px; }
@@ -2121,7 +2121,7 @@ StScrollBar {
 
 #lockDialogGroup {
   // background: #2e3436 url(resource:///org/gnome/shell/theme/noise-texture.png);
-  background: #2c001e url("lockscreen-gradient.svg");
+  background: #2c001e /*url("lockscreen-gradient.svg")*/;
   background-size: cover; // 40px;
   background-position: top right;
   background-repeat: no-repeat; // repeat;


### PR DESCRIPTION
Seen [here](https://user-images.githubusercontent.com/27529229/42391631-031577aa-811e-11e8-8076-e86cd259931c.png). Discussion is over in #183 

I dropped the Ubuntu background-image since we're still in early discuss and adjust mode.

Some notes:

- `background-position` doesn't seem to work in the Shell.
- `box-shadow` doesn't seem to work with `background-image`, a strange border gets drawn behind the widget if you try to combine the two properties. 