### PR TITLE
Darken app switchers text color & add a box-shadow to osd-panels

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -768,6 +768,7 @@ StScrollBar {
   border: 1px solid $osd_borders_color;
   border-radius: $large_radius;
   padding: 12px;
+  box-shadow: 0 3px 9px 1px transparentize(black, 0.5);
 }
 
 %dialog_window {

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -678,7 +678,7 @@ StScrollBar {
     padding: 8px;
     border-radius: $small_radius;
     //color: $dark_subtext_color;
-    color: $fg_color;
+    color: darken($fg_color,30%);
   }
 
   .switcher-list .item-box:outlined {


### PR DESCRIPTION
Closes https://github.com/ubuntu/gtk-communitheme/issues/612