### PR TITLE
Adapt the :checked popupmenu elemtnt's bottom box-shadow to the submenu

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -560,13 +560,21 @@ StScrollBar {
     &:ltr { padding: .4em 1.75em .4em 0em; }
     &:rtl { padding: .4em 0em .4em 1.75em; }
     &:checked {
-      box-shadow: inset 0 -1px 0px $bc;
+      //less transparency than $osd_borders_color to match the bottom color of the submenu
+      box-shadow: inset 0 -1px 0px transparentize($fg_color, 0.855);
       background-color: transparent;
       border-top-color: transparent;
       font-weight: bold;
+      &:hover {
+        box-shadow: none;
+      }
     }
     &.selected { background-color: $base_hover_color; color: $fg_color; }
-    &:active { background-color: $base_active_color; color: $active_fg_color; }
+    &:active {
+      background-color: $base_active_color;
+      color: $active_fg_color;
+      box-shadow: none;
+    }
     &:insensitive { color: transparentize($fg_color,.5); }
   }
 

--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -565,9 +565,6 @@ StScrollBar {
       background-color: transparent;
       border-top-color: transparent;
       font-weight: bold;
-      &:hover {
-        box-shadow: none;
-      }
     }
     &.selected { background-color: $base_hover_color; color: $fg_color; }
     &:active {


### PR DESCRIPTION
Closes https://github.com/ubuntu/gnome-shell-communitheme/issues/231

@madsrh  Also remove the box-shadow on active and checked:hover
This caused the popping of that line 

![peek 2018-07-09 12-34](https://user-images.githubusercontent.com/15329494/42445744-60b53794-8374-11e8-91a6-d83247bbd81f.gif)

