### PR TITLE
Remove the ubuntu logo in activities, add the new grid icon again

### DIFF
--- a/communitheme/gnome-shell-sass/_common.scss
+++ b/communitheme/gnome-shell-sass/_common.scss
@@ -2113,14 +2113,8 @@ StScrollBar {
 
 #panel.lock-screen { background-color: transparent; }
 
-#panelActivities.panel-button {
-    background-image: url("activities.svg");
-    background-size: auto;
-    background-position: center;
-    text-align: right;
-    min-width: 124px;
-    min-height: 24px;
-}
+// This is the "Activities" button
+#panelActivities.panel-button { }
 
 .screen-shield-background { //just the shadow, really
   background: black;

--- a/communitheme/gnome-shell-sass/_dock.scss
+++ b/communitheme/gnome-shell-sass/_dock.scss
@@ -186,12 +186,27 @@
   }
 
   .show-apps {
-     &:active, &:checked {
-       .overview-icon {
-         background-color: $base_active_color;
-         box-shadow: none;
-       }
-     }
+    // Show apps icon
+    & {
+      // reset
+      & .show-apps-icon,
+      &:checked .show-apps-icon,
+      &:focus .show-apps-icon {
+        color: transparent !important;
+        background-color: transparent !important;
+        transition-duration: 0ms !important;
+      }
+    }
+
+    &,
+    &:hover, &:active, &:checked {
+      .show-apps-icon {
+        background-image: url("ubuntu-appgrid-icon.svg") !important;
+        background-position: center;
+        background-repeat: no-repeat;
+        background-size: contain !important;
+      }
+    }
   }
 
   .app-well-app {

--- a/communitheme/ubuntu-appgrid-icon.svg
+++ b/communitheme/ubuntu-appgrid-icon.svg
@@ -53,9 +53,9 @@
      showgrid="false"
      inkscape:current-layer="g2297"
      inkscape:document-units="px"
-     inkscape:cy="24.325347"
-     inkscape:cx="6.0176477"
-     inkscape:zoom="7.9308686"
+     inkscape:cy="22.039595"
+     inkscape:cx="25.038926"
+     inkscape:zoom="15.861737"
      inkscape:pageshadow="2"
      inkscape:pageopacity="0"
      borderopacity="1.0"
@@ -269,102 +269,11 @@
          id="g2297"
          transform="matrix(0.14593061,0,0,0.14593061,98.438482,395.21362)"
          style="stroke-width:6.85257149">
-        <g
-           id="g3897"
-           transform="matrix(1.06456,0,0,1.06456,-21.959039,-47.550347)">
-          <path
-             id="path3843"
-             d="m 245.93292,195.38017 h 90.45745 c 73.06863,0 83.51126,10.41653 83.51126,83.41698 v 76.56515 c 0,73.00011 -10.44263,83.41691 -83.51126,83.41691 h -90.45745 c -73.06849,0 -83.51126,-10.4168 -83.51126,-83.41691 v -76.56515 c 0,-73.00045 10.44277,-83.41698 83.51126,-83.41698 z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.00578117;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:new"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="sssssssss" />
-          <g
-             transform="matrix(7.0823435,0,0,7.0823435,3481.5471,-2747.9946)"
-             id="g16835"
-             style="display:inline">
-            <rect
-               height="3.8036983"
-               id="rect9843"
-               rx="1.901849"
-               ry="1.901849"
-               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.90184855;marker:none;enable-background:new"
-               width="3.8036981"
-               x="-459.97955"
-               y="423.26761" />
-            <rect
-               y="423.26761"
-               x="-452.37216"
-               width="3.8036981"
-               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.90184855;marker:none;enable-background:new"
-               ry="1.901849"
-               rx="1.901849"
-               id="rect9833"
-               height="3.8036983" />
-            <rect
-               height="3.8036983"
-               id="rect9835"
-               rx="1.901849"
-               ry="1.901849"
-               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.90184855;marker:none;enable-background:new"
-               width="3.8036981"
-               x="-444.76477"
-               y="423.26761" />
-            <rect
-               y="430.875"
-               x="-459.97955"
-               width="3.8036981"
-               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.90184855;marker:none;enable-background:new"
-               ry="1.901849"
-               rx="1.901849"
-               id="rect9837"
-               height="3.8036983" />
-            <rect
-               height="3.8036983"
-               id="rect9839"
-               rx="1.901849"
-               ry="1.901849"
-               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.90184855;marker:none;enable-background:new"
-               width="3.8036981"
-               x="-452.37216"
-               y="430.875" />
-            <rect
-               y="430.875"
-               x="-444.76477"
-               width="3.8036981"
-               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.90184855;marker:none;enable-background:new"
-               ry="1.901849"
-               rx="1.901849"
-               id="rect9841"
-               height="3.8036983" />
-            <rect
-               height="3.8036983"
-               id="rect9845"
-               rx="1.901849"
-               ry="1.901849"
-               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.90184855;marker:none;enable-background:new"
-               width="3.8036981"
-               x="-459.97955"
-               y="438.48239" />
-            <rect
-               y="438.48239"
-               x="-452.37216"
-               width="3.8036981"
-               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.90184855;marker:none;enable-background:new"
-               ry="1.901849"
-               rx="1.901849"
-               id="rect9847"
-               height="3.8036983" />
-            <rect
-               height="3.8036983"
-               id="rect9849"
-               rx="1.901849"
-               ry="1.901849"
-               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.90184855;marker:none;enable-background:new"
-               width="3.8036981"
-               x="-444.76477"
-               y="438.48239" />
-          </g>
-        </g>
+        <path
+           inkscape:connector-curvature="0"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.07071412;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:new"
+           d="m 239.8418,160.44302 c -77.78577,0 -88.89324,11.09441 -88.89324,88.80775 v 81.49848 c 0,77.71297 11.10747,88.80775 88.89324,88.80775 h 96.30217 c 77.78592,0 88.90747,-11.09478 88.90747,-88.80775 v -81.49848 c 0,-77.71334 -11.12155,-88.80775 -88.90747,-88.80775 z m -9.20421,57.8611 c 7.94386,0 14.34776,6.38958 14.34776,14.33352 0,7.94386 -6.4039,14.34767 -14.34776,14.34767 -7.94386,0 -14.33353,-6.40381 -14.33353,-14.34767 0,-7.94394 6.38967,-14.33352 14.33353,-14.33352 z m 57.36241,0 c 7.94386,0 14.33345,6.38958 14.33345,14.33352 0,7.94386 -6.38959,14.34767 -14.33345,14.34767 -7.94386,0 -14.34775,-6.40381 -14.34775,-14.34767 0,-7.94394 6.40389,-14.33352 14.34775,-14.33352 z m 57.34818,0 c 7.94386,0 14.34768,6.38958 14.34768,14.33352 0,7.94386 -6.40382,14.34767 -14.34768,14.34767 -7.94393,0 -14.33353,-6.40381 -14.33353,-14.34767 0,-7.94394 6.3896,-14.33352 14.33353,-14.33352 z m -114.71059,57.3624 c 7.94386,0 14.34776,6.3896 14.34776,14.33352 0,7.94386 -6.4039,14.33346 -14.34776,14.33346 -7.94386,0 -14.33353,-6.3896 -14.33353,-14.33346 0,-7.94392 6.38967,-14.33352 14.33353,-14.33352 z m 57.36241,0 c 7.94386,0 14.33345,6.3896 14.33345,14.33352 0,7.94386 -6.38959,14.33346 -14.33345,14.33346 -7.94386,0 -14.34775,-6.3896 -14.34775,-14.33346 0,-7.94392 6.40389,-14.33352 14.34775,-14.33352 z m 57.34818,0 c 7.94386,0 14.34768,6.3896 14.34768,14.33352 0,7.94386 -6.40382,14.33346 -14.34768,14.33346 -7.94393,0 -14.33353,-6.3896 -14.33353,-14.33346 0,-7.94392 6.3896,-14.33352 14.33353,-14.33352 z M 230.63759,333.0147 c 7.94386,0 14.34776,6.40382 14.34776,14.34775 0,7.94386 -6.4039,14.33345 -14.34776,14.33345 -7.94386,0 -14.33353,-6.38959 -14.33353,-14.33345 0,-7.94393 6.38967,-14.34775 14.33353,-14.34775 z m 57.36241,0 c 7.94386,0 14.33345,6.40382 14.33345,14.34775 0,7.94386 -6.38959,14.33345 -14.33345,14.33345 -7.94386,0 -14.34775,-6.38959 -14.34775,-14.33345 0,-7.94393 6.40389,-14.34775 14.34775,-14.34775 z m 57.34818,0 c 7.94386,0 14.34768,6.40382 14.34768,14.34775 0,7.94386 -6.40382,14.33345 -14.34768,14.33345 -7.94393,0 -14.33353,-6.38959 -14.33353,-14.33345 0,-7.94393 6.3896,-14.34775 14.33353,-14.34775 z"
+           id="path3843-9" />
       </g>
     </g>
   </g>


### PR DESCRIPTION
-  Remove the ubuntu icon in activities because of a lot of issues (most of them on the hub as screenshots)
closes https://github.com/ubuntu/gtk-communitheme/issues/627
closes https://github.com/ubuntu/gtk-communitheme/issues/625
(we try to bring the icon into the desktop somehow soon)
- uses the 2. icon @tactiturasa uploaded with transparent grid holes
- removes the transition duration in the app grid which has no use since we only have 1 icon

![screenshot from 2018-07-17 00-12-51](https://user-images.githubusercontent.com/15329494/42786420-8bc1e1ac-8956-11e8-88a1-8c2a0a156a68.png)
